### PR TITLE
Support for .git-ftp-including files without any git dependencies

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -514,6 +514,13 @@ set_changed_files() {
 	if [ -f '.git-ftp-include' ]; then
 		grep -v '^#.*$\|^\s*$' '.git-ftp-include' | tr -d '\r' > '.git-ftp-include-tmp'
 
+		for LINE in `grep '^!' '.git-ftp-include-tmp'`
+		do
+			FILE_STATUS='M'
+			FILE_PAIR=$(echo "$LINE" | sed 's/^!//')
+			echo "$FILE_STATUS	$FILE_PAIR" >> '.git-ftp-tmp'
+		done
+
 		for LINE in `grep ':' '.git-ftp-include-tmp'`
 		do
 			OIFS="$IFS"


### PR DESCRIPTION
Hi,
I love .git-ftp-include but sometimes you just need to upload non-git files every time.

Say, an automatically generated changelog, or git log -1.

This change makes it possible to add entries like
!templates/devel-version.tpl
to .git-ftp-include (note the exclamation mark).

Such files are always marked as modified and uploaded.

So, for your consideration...
Regards
