### PR TITLE
Fixed a minor formatting issue in INSTALL

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,6 +48,7 @@ Mac OS X
 Warning: git-ftp will not work with OS X 10.8 without GNU grep!
 
 Using homebrew:
+
 	# brew install grep
 	# brew install git
 	# brew install curl --with-ssl --with-ssh


### PR DESCRIPTION
The description of installing via Homebrew on OS X 10.8 isn't rendered as a code block in a Markdown renderer because it's missing a newline.
