### PR TITLE
Bug fix: git init fails when using .git-ftp-include as SHA1_DEPLOYED is ...

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2010-2012 RenÃ© Moser
+# Copyright 2010-2012 René Moser
 # http://github.com/resmo/git-ftp
 #
 # Git-ftp is free software: you can redistribute it and/or modify
@@ -532,7 +532,7 @@ set_changed_files() {
 					IFS=":"
 					SUB_FILE_PAIR=($SUB_LINE)
 					IFS="$OIFS"
-					if [[ $(git diff --name-status --no-renames $DEPLOYED_SHA1 $SYNCROOT -- "${SUB_FILE_PAIR[1]}" | grep '^D') ]]; then
+					if [ $IGNORE_DEPLOYED -eq 0 ] && [[ $(git diff --name-status --no-renames $DEPLOYED_SHA1 $SYNCROOT -- "${SUB_FILE_PAIR[1]}" | grep '^D') ]]; then
 						let DELETE_COUNT++
 					else
 						let MODIFY_COUNT++


### PR DESCRIPTION
When running "git init", git-ftp should not call git-diff when IGNORE_DEPLOYED is set.
PS. Apologies but git seems to have corrupted your name on change set. I've tried a couple of times and it keeps insisting on changing the line.
