### PR TITLE
Error: binary operator expected.

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -755,9 +755,9 @@ set_remote_password() {
 }
 
 set_syncroot() {
-	[ -z $SYNCROOT ] && SYNCROOT="$(get_config syncroot)"
-	if [ $SYNCROOT ]; then
-		[ -d $SYNCROOT ] || print_error_and_die "'$SYNCROOT' is not a directory! Exiting..." $ERROR_GIT
+	[ -z "$SYNCROOT" ] && SYNCROOT="$(get_config syncroot)"
+	if [ "$SYNCROOT" ]; then
+		[ -d "$SYNCROOT" ] || print_error_and_die "'$SYNCROOT' is not a directory! Exiting..." $ERROR_GIT
 		SYNCROOT=$(echo $SYNCROOT | sed 's#/*$##')/
 	fi
 }


### PR DESCRIPTION
Patch on Windows 7 X64 (Build 7600) and Ubuntu 10.04.4 environment throwing error binary operator expected.
