### PR TITLE
Update Windows installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -68,13 +68,10 @@ otherwise install msysgit.
 After this, open git bash (or cygwin bash for cygwin only):
 
 	$ cd ~
-	$ git clone https://github.com/git-ftp/git-ftp git-ftp.git
-	$ cd git-ftp.git && chmod +x git-ftp
-	$ cp ~/git-ftp.git/git-ftp /bin/git-ftp
-
-__Important:__ Because Windows does not support symbolic links (shortcuts),
-the above steps will create a copy of the git-ftp script in your /bin/ directory.
-If you update your git-ftp clone, you will have to repeat the last command.
+	$ git clone https://github.com/git-ftp/git-ftp
+	$ cd git-ftp && chmod +x git-ftp
+	$ cd /bin
+	$ ln -s ~/git-ftp/git-ftp
 
 *Note: the /bin/ directory is a alias, and if you use msysgit this is the same as C:\Program Files (x86)\Git\bin\*
 


### PR DESCRIPTION
Windows does support symlinks. Through command prompt, they must be created using the `mklink` command. Through bash, you can use the `ln` command.

No second argument is needed on the `git clone` or `ln` commands, as it is implied.
