### PR TITLE
fix curl verbosity and error message display

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -412,9 +412,9 @@ remove_file() {
 		curl "${CURL_ARGS[@]}"
 	else
 		curl "${CURL_ARGS[@]}" > /dev/null 2>&1
-		if [ $? -ne 0 ]; then
-			write_error_log "Could not delete ${REMOTE_PATH}${FILENAME}, continuing..."
-		fi
+	fi
+	if [ $? -ne 0 ]; then
+		write_error_log "Could not delete ${REMOTE_PATH}${FILENAME}, continuing..."
 	fi
 }
 


### PR DESCRIPTION
some functions add to REMOTE_CMD_OPTIONS, so only check the first two characters for "-w"...

while there, fix an error message so it displays even if the failure happened in verbose mode
