### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,7 +48,8 @@ Mac OS X
 Warning: git-ftp will not work with OS X 10.8 without GNU grep!
 
 Using homebrew:
-
+	
+	# brew tap homebrew/dupes
 	# brew install grep
 	# brew install git
 	# brew install curl --with-ssl --with-ssh


### PR DESCRIPTION
OS X: brew install grep fails if you don't have have homebrew/dupes repository added. This commit adds this step.
