### PR TITLE
Replacing readlink with cd and pwd

### DIFF
--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -1,11 +1,9 @@
 #!/bin/sh
 
 oneTimeSetUp() {
-	BASE_PATH=$(readlink -f $TESTDIR/..)/
-	# Maybe this is more robust?
-	#BASE_PATH=$TESTDIR/../
+	cd "$TESTDIR/../"
 
-	GIT_FTP_CMD="${BASE_PATH}git-ftp"
+	GIT_FTP_CMD="$(pwd)/git-ftp"
 	: ${GIT_FTP_USER=ftp}
 	: ${GIT_FTP_PASSWD=}
 	: ${GIT_FTP_ROOT=localhost/}


### PR DESCRIPTION
davidbenton reported that `readlink -f` is not available under OSX.
