### PR TITLE
Fix for url from git config not being identified correctly

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -1157,10 +1157,10 @@ do
 				*)
 					if ! echo "$2" | egrep -q '^-'; then
 						REMOTE_PASSWD="$2"
-						shift
 					else
 						ask_for_passwd
 					fi
+					shift
 					;;
 			esac
 			;;


### PR DESCRIPTION
When the url is stored in the git config, and the password is set to ask (-p -)
the - was being identified as the url.

Fixed by making the script parameter list shift by one after asking for
password.
