### PR TITLE
Testing an empty URL instead of an empty password

### DIFF
--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -165,11 +165,11 @@ test_overwrite_defaults_by_scopes_emtpy_string() {
 	git config git-ftp.password $GIT_FTP_PASSWD
 	git config git-ftp.url $GIT_FTP_URL
 
-	git config git-ftp.testing.password ''
+	git config git-ftp.testing.url ''
 
 	init=$($GIT_FTP_CMD init -s testing 2>/dev/null)
 	rtrn=$?
-	assertEquals 4 $rtrn
+	assertEquals 3 $rtrn
 }
 
 test_scopes_uses_password_by_cli() {


### PR DESCRIPTION
This has two main advantages:
1. If you use an anonymous FTP server for testing, the login with an empty
   password succeeds and this test fails.
2. An empty URL results in an earlier error message that doesn't involve a
   network connection. This saves 20 seconds (invalid password timeout) in
   my testing setup.
