### PR TITLE
Adding Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: sh
+
+before_script:
+  - git config --global user.email "you@example.com"
+  - git config --global user.name "Your Name"
+  - sudo apt-get install -y vsftpd
+  - echo write_enable=YES | sudo tee -a /etc/vsftpd.conf
+  - echo anon_upload_enable=YES | sudo tee -a /etc/vsftpd.conf
+  - echo anon_mkdir_write_enable=YES | sudo tee -a /etc/vsftpd.conf
+  - echo anon_umask=000 | sudo tee -a /etc/vsftpd.conf
+  - echo anon_other_write_enable=YES | sudo tee -a /etc/vsftpd.conf
+  - echo anon_root=/var/ftp | sudo tee -a /etc/vsftpd.conf
+  - sudo mkdir -p /var/ftp/pub
+  - sudo chmod a+rwx /var/ftp/pub
+  - sudo service vsftpd restart
+  - export GIT_FTP_ROOT=localhost/pub/
+  - export GIT_FTP_USER=ftp
+  - export GIT_FTP_PASSWD=ftp
+
+script:
+  - tests/git-ftp-test.sh
+
+after_failure:
+  - ls -la /var/ftp/pub/*
+  - cat /etc/vsftpd.conf


### PR DESCRIPTION
Travis (http://travis-ci.org/) provides free integration testing hooked
into GitHub. Writing this config file (.travis.yml) is the most
difficult part in setting it up. There are only three steps left:
1. Sign into Travis with your GitHub account
2. Activate GitHub webhook for this project
3. Merge this pull request

Only one test will fail unless pull request #136 got merged.
