### PR TITLE
Fixing not recognizing different SHA1 object.

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -595,6 +595,7 @@ set_changed_files() {
 		git ls-files -t $SYNCROOT > '.git-ftp-tmp'
 	else
 		git diff --name-status --no-renames $DEPLOYED_SHA1 $SYNCROOT 2>/dev/null > '.git-ftp-tmp'
+		local git_diff_status=$?
 	fi
 
 	# Add files from include file
@@ -662,7 +663,7 @@ set_changed_files() {
 		return
 	fi
 
-	if [ $? -ne 0 ]; then
+	if [ $git_diff_status -ne 0 ]; then
 		if [ $FORCE -ne 1 ]; then
 			print_info "Unknown SHA1 object, make sure you are deploying the right branch and it is up-to-date."
 			echo -n "Do you want to ignore and upload all files again? [y/N]: "

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -171,6 +171,37 @@ test_push_nothing() {
 	assertEquals 'There are no files to sync.' "$push"
 }
 
+test_push_unknown_sha1() {
+	cd $GIT_PROJECT_PATH
+	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	# make some changes
+	echo "1" >> "./test 1.txt"
+	git commit -a -m "change" > /dev/null 2>&1
+	# change remote SHA1
+	echo '000000000' | curl -T - $CURL_URL/.git-ftp.log 2> /dev/null
+	push=$(echo 'N' | $GIT_FTP_CMD push -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	assertEquals 0 $?
+	echo "$push" | grep 'Unknown SHA1 object' > /dev/null
+	curl -s "$CURL_URL/test 1.txt" | diff - 'test 1.txt' > /dev/null
+	assertEquals 1 $?
+}
+
+test_push_unknown_sha1_Y() {
+	cd $GIT_PROJECT_PATH
+	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	# make some changes
+	echo "1" >> "./test 1.txt"
+	git commit -a -m "change" > /dev/null 2>&1
+	# change remote SHA1
+	echo '000000000' | curl -T - $CURL_URL/.git-ftp.log 2> /dev/null
+	push=$(echo 'Y' | $GIT_FTP_CMD push -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	assertEquals 0 $?
+	echo "$push" | grep 'Unknown SHA1 object' > /dev/null
+	assertEquals 0 $?
+	curl -s "$CURL_URL/test 1.txt" | diff - 'test 1.txt' > /dev/null
+	assertEquals 0 $?
+}
+
 test_defaults() {
 	cd $GIT_PROJECT_PATH
 	git config git-ftp.user $GIT_FTP_USER


### PR DESCRIPTION
genofire mentioned another problem in #5 which should be solved with this patch. The return value of `git diff` was not preserved and a later check did not work.
