### PR TITLE
In test suite: always appending a slash to root path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - sudo mkdir -p /var/ftp/pub
   - sudo chmod a+rwx /var/ftp/pub
   - sudo service vsftpd restart
-  - export GIT_FTP_ROOT=localhost/pub/
+  - export GIT_FTP_ROOT=localhost/pub
   - export GIT_FTP_USER=ftp
   - export GIT_FTP_PASSWD=ftp
 

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -6,7 +6,7 @@ oneTimeSetUp() {
 	GIT_FTP_CMD="$(pwd)/git-ftp"
 	: ${GIT_FTP_USER=ftp}
 	: ${GIT_FTP_PASSWD=}
-	: ${GIT_FTP_ROOT=localhost/}
+	: ${GIT_FTP_ROOT=localhost}
 
 	START=$(date +%s)
 }
@@ -21,7 +21,7 @@ setUp() {
 	GIT_PROJECT_PATH=$(mktemp -d -t git-ftp-XXXX)
 	GIT_PROJECT_NAME=$(basename $GIT_PROJECT_PATH)
 
-	GIT_FTP_URL="$GIT_FTP_ROOT$GIT_PROJECT_NAME"
+	GIT_FTP_URL="$GIT_FTP_ROOT/$GIT_PROJECT_NAME"
 
 	CURL_URL="ftp://$GIT_FTP_USER:$GIT_FTP_PASSWD@$GIT_FTP_URL"
 


### PR DESCRIPTION
Invoking the test suite like this caused errors:

```
GIT_FTP_USER=ftp GIT_FTP_PASSWD=ftp GIT_FTP_ROOT=localhost/test ./tests/git-ftp-test.sh
```

The GIT_FTP_ROOT required a trailing slash. That is changed by this
commit.

That slash isn't required any more. If it's added, the path will contain
two slashes which isn't a problem. I don't see a point in adding code
for canonicalising the path in the test suite.
