### PR TITLE
Handling empty password in test suite

### DIFF
--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -25,6 +25,10 @@ setUp() {
 
 	CURL_URL="ftp://$GIT_FTP_USER:$GIT_FTP_PASSWD@$GIT_FTP_URL"
 
+	[ -n "$GIT_FTP_USER" ] && GIT_FTP_USER_ARG="-u $GIT_FTP_USER"
+	[ -n "$GIT_FTP_PASSWD" ] && GIT_FTP_PASSWD_ARG="-p $GIT_FTP_PASSWD"
+	GIT_FTP="$GIT_FTP_CMD $GIT_FTP_USER_ARG $GIT_FTP_PASSWD_ARG $GIT_FTP_URL"
+
 	cd $GIT_PROJECT_PATH
 
 	# make some content
@@ -62,12 +66,12 @@ test_inits_and_pushes() {
 	cd $GIT_PROJECT_PATH
 
 	# this should pass
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	init=$($GIT_FTP init)
 	rtrn=$?
 	assertEquals 0 $rtrn
 
 	# this should fail
-	init2=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL 2>&1)
+	init2=$($GIT_FTP init 2>&1)
 	rtrn=$?
 	assertEquals 2 $rtrn
 	assertEquals "fatal: Commit found, use 'git ftp push' to sync. Exiting..." "$init2"
@@ -77,7 +81,7 @@ test_inits_and_pushes() {
 	git commit -a -m "change" > /dev/null 2>&1
 
 	# this should pass
-	push=$($GIT_FTP_CMD push -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	push=$($GIT_FTP push)
 	rtrn=$?
 	assertEquals 0 $rtrn
 }
@@ -95,7 +99,7 @@ test_init_more() {
 	git add .
 	git commit -m 'Some more files.' > /dev/null
 
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	init=$($GIT_FTP init)
 	assertEquals 0 $?
 	assertTrue 'file does not exist' "remote_file_exists '${long_prefix}50'"
 
@@ -117,14 +121,14 @@ test_delete_more() {
 	git add .
 	git commit -m 'Some more files.' > /dev/null
 
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	init=$($GIT_FTP init)
 	assertEquals 0 $?
 
 	# Delete a number of files exceeding the upload buffer
 	git rm $long_file_list > /dev/null
 	git commit -m 'Deleting some more files.' > /dev/null
 
-	push=$($GIT_FTP_CMD push -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	push=$($GIT_FTP push)
 	assertEquals 0 $?
 
 	# Counting the number of deletes to estimate correct buffering
@@ -142,14 +146,14 @@ disabled_test_init_heaps() {
 	git add .
 	git commit -m 'A lot of files.' > /dev/null
 
-	$GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL > /dev/null
+	$GIT_FTP init> /dev/null
 	assertEquals 0 $?
 	assertTrue 'file does not exist' "remote_file_exists '3955'"
 }
 
 test_pushes_and_fails() {
 	cd $GIT_PROJECT_PATH
-	push="$($GIT_FTP_CMD push -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL 2>&1)"
+	push="$($GIT_FTP push 2>&1)"
 	rtrn=$?
 	assertEquals "fatal: Could not get last commit. Network down? Wrong URL? Use 'git ftp init' for the initial push., exiting..." "$push"
 	assertEquals 5 $rtrn
@@ -157,29 +161,29 @@ test_pushes_and_fails() {
 
 test_push_nothing() {
 	cd $GIT_PROJECT_PATH
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	init=$($GIT_FTP init)
 	# make some changes
 	echo "1" >> "./test 1.txt"
 	git commit -a -m "change" > /dev/null 2>&1
-	push=$($GIT_FTP_CMD push --dry-run -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	push=$($GIT_FTP push --dry-run)
 	assertEquals 0 $?
 	oneline=$(echo $push)
 	assertEquals "There are 1 files to sync: [1 of 1] Buffered for upload 'test 1.txt'." "$oneline"
 	echo 'test 1.txt' >> .git-ftp-ignore
-	push=$($GIT_FTP_CMD push -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	push=$($GIT_FTP push)
 	assertEquals 0 $?
 	assertEquals 'There are no files to sync.' "$push"
 }
 
 test_push_unknown_sha1() {
 	cd $GIT_PROJECT_PATH
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	init=$($GIT_FTP init)
 	# make some changes
 	echo "1" >> "./test 1.txt"
 	git commit -a -m "change" > /dev/null 2>&1
 	# change remote SHA1
 	echo '000000000' | curl -T - $CURL_URL/.git-ftp.log 2> /dev/null
-	push=$(echo 'N' | $GIT_FTP_CMD push -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	push=$(echo 'N' | $GIT_FTP push)
 	assertEquals 0 $?
 	echo "$push" | grep 'Unknown SHA1 object' > /dev/null
 	curl -s "$CURL_URL/test 1.txt" | diff - 'test 1.txt' > /dev/null
@@ -188,13 +192,13 @@ test_push_unknown_sha1() {
 
 test_push_unknown_sha1_Y() {
 	cd $GIT_PROJECT_PATH
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	init=$($GIT_FTP init)
 	# make some changes
 	echo "1" >> "./test 1.txt"
 	git commit -a -m "change" > /dev/null 2>&1
 	# change remote SHA1
 	echo '000000000' | curl -T - $CURL_URL/.git-ftp.log 2> /dev/null
-	push=$(echo 'Y' | $GIT_FTP_CMD push -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	push=$(echo 'Y' | $GIT_FTP push)
 	assertEquals 0 $?
 	echo "$push" | grep 'Unknown SHA1 object' > /dev/null
 	assertEquals 0 $?
@@ -225,23 +229,25 @@ test_defaults_uses_url_by_cli() {
 }
 
 test_defaults_uses_user_by_cli() {
+	[ -z "$GIT_FTP_USER" ] && startSkipping
 	cd $GIT_PROJECT_PATH
 	git config git-ftp.user johndoe
 	git config git-ftp.password $GIT_FTP_PASSWD
 	git config git-ftp.url $GIT_FTP_URL
 
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER)
+	init=$($GIT_FTP_CMD init $GIT_FTP_USER_ARG)
 	rtrn=$?
 	assertEquals 0 $rtrn
 }
 
 test_defaults_uses_password_by_cli() {
+	[ -z "$GIT_FTP_PASSWD" ] && startSkipping
 	cd $GIT_PROJECT_PATH
 	git config git-ftp.user $GIT_FTP_USER
 	git config git-ftp.password wrongpasswd
 	git config git-ftp.url $GIT_FTP_URL
 
-	init=$($GIT_FTP_CMD init -p $GIT_FTP_PASSWD)
+	init=$($GIT_FTP_CMD init $GIT_FTP_PASSWD_ARG)
 	rtrn=$?
 	assertEquals 0 $rtrn
 }
@@ -292,7 +298,7 @@ test_scopes_uses_password_by_cli() {
 
 	git config git-ftp.testing.password wrongpasswdtoo
 
-	init=$($GIT_FTP_CMD init -s testing -p $GIT_FTP_PASSWD)
+	init=$($GIT_FTP_CMD init -s testing $GIT_FTP_PASSWD_ARG)
 	rtrn=$?
 	assertEquals 0 $rtrn
 }
@@ -300,14 +306,14 @@ test_scopes_uses_password_by_cli() {
 test_delete() {
 	cd $GIT_PROJECT_PATH
 
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	init=$($GIT_FTP init)
 
 	assertTrue 'test failed: file does not exist' "remote_file_exists 'test 1.txt'"
 
 	git rm "test 1.txt" > /dev/null 2>&1
 	git commit -a -m "delete file" > /dev/null 2>&1
 
-	push=$($GIT_FTP_CMD push -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	push=$($GIT_FTP push)
 
 	assertFalse 'test failed: file still exists' "remote_file_exists 'test 1.txt'"
 	assertTrue 'test failed: file does not exist' "remote_file_exists 'dir 1/test 1.txt'"
@@ -315,7 +321,7 @@ test_delete() {
 	git rm -r "dir 1" > /dev/null 2>&1
 	git commit -a -m "delete dir" > /dev/null 2>&1
 
-	push=$($GIT_FTP_CMD push -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	push=$($GIT_FTP push)
 
 	assertFalse 'test failed: dir and file still exists' "remote_file_exists 'dir 1/test 1.txt'"
 	assertFalse 'test failed: dir still exists' "remote_file_exists 'dir 1/'"
@@ -325,7 +331,7 @@ test_ignore_single_file() {
 	cd $GIT_PROJECT_PATH
 	echo "test 1\.txt" > .git-ftp-ignore
 
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	init=$($GIT_FTP init)
 
 	assertFalse 'test failed: file was not ignored' "remote_file_exists 'test 1.txt'"
 }
@@ -334,7 +340,7 @@ test_ignore_dir() {
 	cd $GIT_PROJECT_PATH
 	echo "dir 1/.*" > .git-ftp-ignore
 
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	init=$($GIT_FTP init)
 
 	assertFalse 'test failed: dir was not ignored' "remote_file_exists 'dir 1/test 1.txt'"
 	assertTrue 'test failed: wrong dir was ignored' "remote_file_exists 'dir 2/test 2.txt'"
@@ -344,7 +350,7 @@ test_ignore_pattern() {
 	cd $GIT_PROJECT_PATH
 	echo "test" > .git-ftp-ignore
 
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	init=$($GIT_FTP init)
 
 	for i in 1 2 3 4 5
 	do
@@ -357,7 +363,7 @@ test_ignore_pattern_single() {
 	echo 'test' > 'test'
 	echo "^test$" > .git-ftp-ignore
 
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	init=$($GIT_FTP init)
 
 	assertFalse 'test failed: was not ignored' "remote_file_exists 'test'"
 	for i in 1 2 3 4 5
@@ -370,7 +376,7 @@ test_ignore_wildcard_files() {
 	cd $GIT_PROJECT_PATH
 	echo "test.*\.txt" > .git-ftp-ignore
 
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	init=$($GIT_FTP init)
 
 	for i in 1 2 3 4 5
 	do
@@ -386,7 +392,7 @@ test_include_init() {
 	echo 'new content' >> 'test 1.txt'
 	git add .
 	git commit -m 'unversioned file unversioned.txt should be uploaded with test 1.txt' > /dev/null
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	init=$($GIT_FTP init)
 	assertTrue 'unversioned.txt was not uploaded' "remote_file_exists 'unversioned.txt'"
 }
 
@@ -397,20 +403,20 @@ test_include_whitespace_init() {
 	echo 'unversioned.txt:test X.txt' > .git-ftp-include
 	git add .
 	git commit -m 'unversioned file unversioned.txt should not be uploaded. test X.txt does not exist.' > /dev/null
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	init=$($GIT_FTP init)
 	assertFalse 'unversioned.txt was uploaded' "remote_file_exists 'unversioned.txt'"
 }
 
 test_include_push() {
 	cd $GIT_PROJECT_PATH
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	init=$($GIT_FTP init)
 	echo 'unversioned' > unversioned.txt
 	echo 'unversioned.txt' >> .gitignore
 	echo 'unversioned.txt:test 1.txt' > .git-ftp-include
 	echo 'new content' >> 'test 1.txt'
 	git add .
 	git commit -m 'unversioned file unversioned.txt should be uploaded with test 1.txt' > /dev/null
-	push=$($GIT_FTP_CMD push -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	push=$($GIT_FTP push)
 	assertTrue 'unversioned.txt was not uploaded' "remote_file_exists 'unversioned.txt'"
 }
 
@@ -422,21 +428,21 @@ test_include_ignore_init() {
 	echo '.htaccess.prod' > .gitignore
 	git add .
 	git commit -m 'htaccess setup' > /dev/null
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	init=$($GIT_FTP init)
 	assertTrue ' .htaccess was ignored' "remote_file_exists '.htaccess'"
 	assertFalse ' .htaccess.prod was uploaded' "remote_file_exists '.htaccess.prod'"
 }
 
 test_include_ignore_push() {
 	cd $GIT_PROJECT_PATH
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	init=$($GIT_FTP init)
 	echo 'htaccess' > .htaccess
 	echo 'htaccess.prod' > .htaccess.prod
 	echo '.htaccess:.htaccess.prod' > .git-ftp-include
 	echo '.htaccess.prod' > .gitignore
 	git add .
 	git commit -m 'htaccess setup' > /dev/null
-	push=$($GIT_FTP_CMD push -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	push=$($GIT_FTP push)
 	assertTrue ' .htaccess was ignored' "remote_file_exists '.htaccess'"
 	assertFalse ' .htaccess.prod was uploaded' "remote_file_exists '.htaccess.prod'"
 }
@@ -449,21 +455,21 @@ test_include_ftp_ignore_init() {
 	echo '.htaccess.prod' > .git-ftp-ignore
 	git add .
 	git commit -m 'htaccess setup' > /dev/null
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	init=$($GIT_FTP init)
 	assertTrue ' .htaccess was ignored' "remote_file_exists '.htaccess'"
 	assertFalse ' .htaccess.prod was uploaded' "remote_file_exists '.htaccess.prod'"
 }
 
 test_include_ftp_ignore_push() {
 	cd $GIT_PROJECT_PATH
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	init=$($GIT_FTP init)
 	echo 'htaccess' > .htaccess
 	echo 'htaccess.prod' > .htaccess.prod
 	echo '.htaccess:.htaccess.prod' > .git-ftp-include
 	echo '.htaccess.prod' > .git-ftp-ignore
 	git add .
 	git commit -m 'htaccess setup' > /dev/null
-	push=$($GIT_FTP_CMD push -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	push=$($GIT_FTP push)
 	assertTrue ' .htaccess was ignored' "remote_file_exists '.htaccess'"
 	assertFalse ' .htaccess.prod was uploaded' "remote_file_exists '.htaccess.prod'"
 }
@@ -478,7 +484,7 @@ test_include_similar() {
 	echo 'new content' >> 'templates/foo.html'
 	git add .
 	git commit -m 'unversioned file foo.html should be uploaded with templates/foo.html' > /dev/null
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	init=$($GIT_FTP init)
 	assertTrue 'foo.html was not uploaded' "remote_file_exists 'foo.html'"
 	assertTrue 'templates/foo.html was not uploaded' "remote_file_exists 'templates/foo.html'"
 }
@@ -488,7 +494,7 @@ test_hidden_file_only() {
 	echo "test" > .htaccess
 	git add . > /dev/null 2>&1
 	git commit -a -m "init" > /dev/null 2>&1
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	init=$($GIT_FTP init)
 	assertTrue 'test failed: .htaccess not uploaded' "remote_file_exists '.htaccess'"
 }
 
@@ -499,13 +505,13 @@ test_file_with_nonchar() {
 	git add . > /dev/null 2>&1
 	git commit -a -m "init" > /dev/null 2>&1
 
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	init=$($GIT_FTP init)
 	assertTrue 'test failed: #4253-Release Contest.md not uploaded' "remote_file_exists '#4253-Release Contest.md'"
 
 	git rm './#4253-Release Contest.md' > /dev/null 2>&1
 	git commit -a -m "delete" > /dev/null 2>&1
 
-	push=$($GIT_FTP_CMD push -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL)
+	push=$($GIT_FTP push)
 	assertFalse 'test failed: #4253-Release Contest.md still exists in '$CURL_URL "remote_file_exists '\#4253-Release Contest.md'"
 }
 
@@ -514,7 +520,7 @@ test_syncroot() {
 	mkdir foobar && echo "test" > foobar/syncroot.txt
 	git add . > /dev/null 2>&1
 	git commit -a -m "syncroot test" > /dev/null 2>&1
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD --syncroot foobar $GIT_FTP_URL)
+	init=$($GIT_FTP init --syncroot foobar)
 	assertTrue 'test failed: syncroot.txt not there as expected' "remote_file_exists 'syncroot.txt'"
 }
 
@@ -524,7 +530,7 @@ disabled_test_file_named_dash() {
 	assertTrue 'test failed: file named - not there as expected' "[ -f '$GIT_PROJECT_PATH/-' ]"
 	git add . > /dev/null 2>&1
 	git commit -a -m "file named - test" > /dev/null 2>&1
-	init=$($GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD)
+	init=$($GIT_FTP init)
 	rtrn=$?
 	assertEquals 0 $rtrn
 }


### PR DESCRIPTION
When no password was given, the tests still put '-p' in their calls.
That resulted in an error 'Remote host not set' because the remote host
was mistaken as a password.

All duplicate code like

```
$GIT_FTP_CMD init -u $GIT_FTP_USER -p $GIT_FTP_PASSWD $GIT_FTP_URL
```

is now in one place and tests can just call:

```
$GIT_FTP init
```

That should increase the readability as well.
