### PR TITLE
Always ignore and include

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -585,10 +585,35 @@ set_deployed_sha1() {
 set_changed_files() {
 	# Get raw list of files
 	if [ $IGNORE_DEPLOYED -ne 0 ]; then
+		write_log "Taking all files.";
 		git ls-files -t $SYNCROOT > '.git-ftp-tmp'
 	else
 		git diff --name-status --no-renames $DEPLOYED_SHA1 $SYNCROOT 2>/dev/null > '.git-ftp-tmp'
 		local git_diff_status=$?
+		local changed_file_count=$(cat '.git-ftp-tmp' | wc -l)
+		if [ "$git_diff_status" -ne 0 ]; then
+			if [ $FORCE -ne 1 ]; then
+				print_info "Unknown SHA1 object, make sure you are deploying the right branch and it is up-to-date."
+				echo -n "Do you want to ignore and upload all files again? [y/N]: "
+				read ANSWER_STATE
+				if [ "$ANSWER_STATE" != "y" ] && [ "$ANSWER_STATE" != "Y" ]; then
+					print_info "Aborting..."
+					exit 0
+				else
+					write_log "Taking all files.";
+					git ls-files -t $SYNCROOT > '.git-ftp-tmp'
+				fi
+			else
+				print_info "Unknown SHA1 object, could not determine changed filed, taking all files."
+				git ls-files -t $SYNCROOT > '.git-ftp-tmp'
+			fi
+		elif [ "$LOCAL_SHA1" == "$DEPLOYED_SHA1" ]; then
+			print_info "No changed files for $REMOTE_HOST/$REMOTE_PATH. Everything up-to-date."
+			exit 0
+		elif [ "$changed_file_count" -eq 0 ]; then
+			write_log "No changed files, but different commit ID. Changed files ignored or commit amended.";
+			return
+		fi
 	fi
 
 	# Add files from include file
@@ -660,34 +685,10 @@ set_changed_files() {
 	rm -f '.git-ftp-include-tmp'
 	rm -f '.git-ftp-ignore-tmp'
 
-	if [ $IGNORE_DEPLOYED -ne 0 ]; then
-		write_log "Sync all files."
-		return
-	fi
-
-	if [ $git_diff_status -ne 0 ]; then
-		if [ $FORCE -ne 1 ]; then
-			print_info "Unknown SHA1 object, make sure you are deploying the right branch and it is up-to-date."
-			echo -n "Do you want to ignore and upload all files again? [y/N]: "
-			read ANSWER_STATE
-			if [ "$ANSWER_STATE" != "y" ] && [ "$ANSWER_STATE" != "Y" ]; then
-				print_info "Aborting..."
-				exit 0
-			else
-				write_log "Taking all files.";
-				FILES_CHANGED="$(git ls-files -t $SYNCROOT)"
-			fi
-		else
-			print_info "Unknown SHA1 object, could not determine changed filed, taking all files."
-			FILES_CHANGED="$(git ls-files -t $SYNCROOT)"
-		fi
-	elif [ -n "$FILES_CHANGED" ]; then
-		write_log "Having changed files.";
-	elif [ "$LOCAL_SHA1" != "$DEPLOYED_SHA1" ]; then
-		write_log "No changed files, but different commit ID. Changed files ignored or commit amended.";
+	if [ -n "$FILES_CHANGED" ]; then
+		write_log "Having files to sync.";
 	else
-		print_info "No changed files for $REMOTE_HOST/$REMOTE_PATH. Everything up-to-date."
-		exit 0
+		write_log "No files to sync. All changed files ignored.";
 	fi
 }
 

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -408,6 +408,18 @@ test_ignore_single_file() {
 	assertFalse 'test failed: file was not ignored' "remote_file_exists 'test 1.txt'"
 }
 
+test_ignore_single_file_force_unknown_commit() {
+	init=$($GIT_FTP init)
+	local file='ignored.txt'
+	touch $file
+	echo $file > .git-ftp-ignore
+	git add .
+	git commit -m 'added new file that should be ignored' -q
+	echo '000000000' | curl -s -T - $CURL_URL/.git-ftp.log
+	push=$($GIT_FTP push -f)
+	assertFalse 'test failed: file was not ignored' "remote_file_exists '$file'"
+}
+
 test_ignore_dir() {
 	cd $GIT_PROJECT_PATH
 	echo "dir 1/.*" > .git-ftp-ignore


### PR DESCRIPTION
Always consider ignore and include lists

The list of changed files was reset to the all-files list if
1. the remote sha1 was unknown and
2. the user decided to ignore that (e.g. --force).

This commit puts the check for an unknown sha1 before .git-ftp-ignore
and .git-ftp-include are considered.

And if no files changed, the ignore and include lists are not considered
at all.
