### PR TITLE
Using colon in username

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -888,8 +888,10 @@ set_remotes() {
 	local REMOTE_LOGIN=''
 	local DISPLAY_LOGIN=''
 	if [ ! -z $REMOTE_USER ]; then
-		REMOTE_LOGIN="$REMOTE_USER":"$REMOTE_PASSWD"@
-		DISPLAY_LOGIN="$REMOTE_USER":'***'@
+		local ENC_USER="$(urlencode "$REMOTE_USER")"
+		local ENC_PASSWD="$(urlencode "$REMOTE_PASSWD")"
+		REMOTE_LOGIN="$ENC_USER":"$ENC_PASSWD"@
+		DISPLAY_LOGIN="$ENC_USER":'***'@
 	fi
 
 	set_remote_protocol
@@ -907,6 +909,22 @@ set_remotes() {
 	
 	set_curl_insecure
 	write_log "Insecure is '$CURL_INSECURE'."
+}
+
+# Original implementation http://stackoverflow.com/a/10660730/3377535
+urlencode() {
+	local string="${1}"
+	local strlen=${#string}
+	local encoded=""
+	for (( pos=0 ; pos<strlen ; pos++ )); do
+		c=${string:$pos:1}
+		case "$c" in
+			[-_.~a-zA-Z0-9] ) o="${c}" ;;
+			* )               printf -v o '%%%02x' "'$c"
+		esac
+		encoded+="${o}"
+	done
+	echo "${encoded}"
 }
 
 set_curl_insecure() {
@@ -1037,7 +1055,7 @@ check_remote_access() {
 	CURL_ARGS+=(--ftp-create-dirs)
 	CURL_ARGS+=("$REMOTE_BASE_URL/$REMOTE_PATH")
 	curl "${CURL_ARGS[@]}" > /dev/null
-	check_exit_status "Can't access remote '$REMOTE_BASE_URL_DISPLAY'." "$ERROR_DOWNLOAD"
+	check_exit_status "Can't access remote '$REMOTE_BASE_URL_DISPLAY'" "$ERROR_DOWNLOAD"
 }
 
 check_deployed_sha1() {

--- a/git-ftp
+++ b/git-ftp
@@ -31,10 +31,11 @@ readonly VERSION='1.1.0-UNRELEASED'
 # ------------------------------------------------------------
 URL=""
 REMOTE_PROTOCOL=""
-REMOTE_LOGIN=""
 REMOTE_HOST=""
 REMOTE_USER=""
 REMOTE_PASSWD=""
+REMOTE_BASE_URL=""
+REMOTE_BASE_URL_DISPLAY=""
 REMOTE_ROOT=""
 REMOTE_PATH=""
 REMOTE_CACERT=""
@@ -378,7 +379,7 @@ upload_file() {
 	set_default_curl_options
 	CURL_ARGS+=(-T "$SRC_FILE")
 	CURL_ARGS+=(--ftp-create-dirs)
-	CURL_ARGS+=("$REMOTE_PROTOCOL://$REMOTE_LOGIN$REMOTE_HOST/${REMOTE_PATH}${DEST_FILE}")
+	CURL_ARGS+=("$REMOTE_BASE_URL/${REMOTE_PATH}${DEST_FILE}")
 	curl "${CURL_ARGS[@]}"
 	check_exit_status "Could not upload file: '${REMOTE_PATH}$DEST_FILE'." "$ERROR_UPLOAD"
 }
@@ -399,7 +400,7 @@ upload_file_buffered() {
 	fi
 
 	ADD_ARGS+=(-T "./$SRC_FILE")
-	ADD_ARGS+=("$REMOTE_PROTOCOL://$REMOTE_LOGIN$REMOTE_HOST/${REMOTE_PATH}${DEST_FILE}")
+	ADD_ARGS+=("$REMOTE_BASE_URL/${REMOTE_PATH}${DEST_FILE}")
 	set_upload_curl_arguments
 	if is_arg_max_reached "${CURL_ARGS[@]}" "${ADD_ARGS[@]}"; then
 		IFS="$OIFS"
@@ -425,7 +426,7 @@ delete_file() {
 	local FILENAME="$1"
 	set_default_curl_options
 	CURL_ARGS+=(-Q "${REMOTE_DELETE_CMD}${REMOTE_PATH}${FILENAME}")
-	CURL_ARGS+=("$REMOTE_PROTOCOL://$REMOTE_LOGIN$REMOTE_HOST")
+	CURL_ARGS+=("$REMOTE_BASE_URL")
 	if [ "${REMOTE_CMD_OPTIONS:0:2}" = "-v" ]; then
 		curl "${CURL_ARGS[@]}"
 	else
@@ -439,7 +440,7 @@ delete_file() {
 set_delete_curl_arguments() {
 	set_default_curl_options
 	CURL_ARGS+=("${CURL_DELETE[@]}")
-	CURL_ARGS+=("$REMOTE_PROTOCOL://$REMOTE_LOGIN$REMOTE_HOST")
+	CURL_ARGS+=("$REMOTE_BASE_URL")
 }
 
 delete_file_buffered() {
@@ -487,7 +488,7 @@ delete_dir() {
 get_file_content() {
 	local SRC_FILE="$1"
 	set_default_curl_options
-	CURL_ARGS+=("$REMOTE_PROTOCOL://$REMOTE_LOGIN$REMOTE_HOST/${REMOTE_PATH}${SRC_FILE}")
+	CURL_ARGS+=("$REMOTE_BASE_URL/${REMOTE_PATH}${SRC_FILE}")
 	curl "${CURL_ARGS[@]}"
 }
 
@@ -497,7 +498,7 @@ set_local_sha1() {
 
 upload_local_sha1() {
 	DEPLOYED_SHA1=$LOCAL_SHA1
-	write_log "Uploading commit log to $REMOTE_PROTOCOL://$REMOTE_LOGIN$REMOTE_HOST/${REMOTE_PATH}$DEPLOYED_SHA1_FILE."
+	write_log "Uploading commit log to $REMOTE_BASE_URL_DISPLAY/${REMOTE_PATH}$DEPLOYED_SHA1_FILE."
 	if [ $DRY_RUN -ne 1 ]; then
 		echo "$DEPLOYED_SHA1" | upload_file - "$DEPLOYED_SHA1_FILE"
 		check_exit_status "Could not upload." "$ERROR_UPLOAD"
@@ -575,7 +576,7 @@ set_deployed_sha1() {
 		return
 	fi
 	# Get the last commit (SHA) we deployed if not ignored or not found
-	write_log "Retrieving last commit from $REMOTE_PROTOCOL://$REMOTE_HOST/$REMOTE_PATH."
+	write_log "Retrieving last commit from $REMOTE_BASE_URL_DISPLAY/$REMOTE_PATH."
 	DEPLOYED_SHA1="$(get_file_content "$DEPLOYED_SHA1_FILE")"
 	check_exit_status "Could not get last commit. Network down? Wrong URL? Use 'git ftp init' for the initial push." "$ERROR_DOWNLOAD"
 	write_log "Last deployed SHA1 for $REMOTE_HOST/$REMOTE_PATH is $DEPLOYED_SHA1."
@@ -884,13 +885,19 @@ set_remotes() {
 		write_log "Password is set."
 	fi 
 
+	local REMOTE_LOGIN=''
+	local DISPLAY_LOGIN=''
 	if [ ! -z $REMOTE_USER ]; then
 		REMOTE_LOGIN="$REMOTE_USER":"$REMOTE_PASSWD"@
+		DISPLAY_LOGIN="$REMOTE_USER":'***'@
 	fi
 
 	set_remote_protocol
 	set_remote_path
 	write_log "Path is '$REMOTE_PATH'."
+
+	REMOTE_BASE_URL="$REMOTE_PROTOCOL://$REMOTE_LOGIN$REMOTE_HOST"
+	REMOTE_BASE_URL_DISPLAY="$REMOTE_PROTOCOL://$DISPLAY_LOGIN$REMOTE_HOST"
 
 	set_syncroot
 	write_log "Syncroot is '$SYNCROOT'."
@@ -1025,17 +1032,16 @@ action_remove_scope() {
 # Checks
 # ------------------------------------------------------------
 check_remote_access() {
-	local url="$REMOTE_PROTOCOL://$REMOTE_LOGIN$REMOTE_HOST/$REMOTE_PATH"
-	write_log "Check if $url is accessible."
+	write_log "Check if $REMOTE_BASE_URL_DISPLAY is accessible."
 	set_default_curl_options
 	CURL_ARGS+=(--ftp-create-dirs)
-	CURL_ARGS+=("$url")
+	CURL_ARGS+=("$REMOTE_BASE_URL/$REMOTE_PATH")
 	curl "${CURL_ARGS[@]}" > /dev/null
-	check_exit_status "Can't access remote '$url'." "$ERROR_DOWNLOAD"
+	check_exit_status "Can't access remote '$REMOTE_BASE_URL_DISPLAY'." "$ERROR_DOWNLOAD"
 }
 
 check_deployed_sha1() {
-	write_log "Check if $REMOTE_PROTOCOL://$REMOTE_HOST/$REMOTE_PATH is clean."
+	write_log "Check if $REMOTE_BASE_URL_DISPLAY/$REMOTE_PATH is clean."
 	DEPLOYED_SHA1="$(get_file_content "$DEPLOYED_SHA1_FILE")"
 	if [ "$DEPLOYED_SHA1" != "" ]; then
 		print_error_and_die "Commit found, use 'git ftp push' to sync. Exiting..." "$ERROR_USAGE"

--- a/git-ftp
+++ b/git-ftp
@@ -887,7 +887,7 @@ set_remotes() {
 
 	local REMOTE_LOGIN=''
 	local DISPLAY_LOGIN=''
-	if [ ! -z $REMOTE_USER ]; then
+	if [ ! -z "$REMOTE_USER" ]; then
 		local ENC_USER="$(urlencode "$REMOTE_USER")"
 		local ENC_PASSWD="$(urlencode "$REMOTE_PASSWD")"
 		REMOTE_LOGIN="$ENC_USER":"$ENC_PASSWD"@


### PR DESCRIPTION
The only way to give curl a username that contains a colon (:) is to encode it in the URL (http://curl.haxx.se/mail/archive-2009-12/0009.html). These commits add url-encoding of username and password and put these into the remote url instead of giving `--user <user:password>`.