### PR TITLE
Filtering with shell glob patterns instead of regex

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -643,10 +643,20 @@ filter_ignore_files() {
 }
 
 filter_file() {
+	glob_filter "$1" < "$2" > '.git-ftp-filtered-tmp'
+	mv '.git-ftp-filtered-tmp' "$2"
+}
+
+# Original implementation http://stackoverflow.com/a/27718468/3377535
+glob_filter() {
 	local patterns="$1"
-	local file="$2"
-	grep --invert-match -f $patterns $file > '.git-ftp-filtered-tmp'
-	mv '.git-ftp-filtered-tmp' $file
+	while IFS= read -r filename; do
+		local hasmatch=0
+		while IFS= read -r pattern; do
+			case $filename in ($pattern) hasmatch=1; break ;; esac
+		done < "$patterns"
+		test $hasmatch = 1 || printf '%s\n' "$filename"
+	done
 }
 
 handle_file_sync() {

--- a/man/git-ftp.1.md
+++ b/man/git-ftp.1.md
@@ -202,20 +202,20 @@ Deleting scopes is easy using the `remove-scope` action.
 
 # IGNORING FILES TO BE SYNCED
 
-Add patterns to `.git-ftp-ignore`. All matching file names will be ignored.
-The patterns are interpreted as regular expressions by `grep`.
+Add patterns to `.git-ftp-ignore` and all matching file names will be ignored.
+The patterns are interpreted as shell glob patterns.
 
 For example, ignoring everything in a directory named `config`:
 
-	config/.*
+	config/*
 
 Ignoring all files having extension `.txt`:
 
-	.*\.txt
+	*.txt
 
 Ignoring a single file called `foobar.txt`:
 
-	^foobar\.txt$
+	foobar.txt
 
 # SYNCING UNTRACKED FILES
 

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -348,7 +348,7 @@ test_delete() {
 
 test_ignore_single_file() {
 	cd $GIT_PROJECT_PATH
-	echo "test 1\.txt" > .git-ftp-ignore
+	echo "test 1.txt" > .git-ftp-ignore
 
 	init=$($GIT_FTP init)
 
@@ -369,7 +369,7 @@ test_ignore_single_file_force_unknown_commit() {
 
 test_ignore_dir() {
 	cd $GIT_PROJECT_PATH
-	echo "dir 1/.*" > .git-ftp-ignore
+	echo "dir 1/*" > .git-ftp-ignore
 
 	init=$($GIT_FTP init)
 
@@ -379,7 +379,7 @@ test_ignore_dir() {
 
 test_ignore_pattern() {
 	cd $GIT_PROJECT_PATH
-	echo "test" > .git-ftp-ignore
+	echo "test*" > .git-ftp-ignore
 
 	init=$($GIT_FTP init)
 
@@ -392,7 +392,7 @@ test_ignore_pattern() {
 test_ignore_pattern_single() {
 	cd $GIT_PROJECT_PATH
 	echo 'test' > 'test'
-	echo "^test$" > .git-ftp-ignore
+	echo 'test' > .git-ftp-ignore
 	git add .
 	git commit -m 'adding file that should not be uploaded' > /dev/null
 
@@ -407,7 +407,7 @@ test_ignore_pattern_single() {
 
 test_ignore_wildcard_files() {
 	cd $GIT_PROJECT_PATH
-	echo "test.*\.txt" > .git-ftp-ignore
+	echo "test *.txt" > .git-ftp-ignore
 
 	init=$($GIT_FTP init)
 


### PR DESCRIPTION
Using a POSIX shell statement to filter file lists. This implementation
is probably a lot slower than the previous `grep` calls and could be
optimised.

This should solve #80.