### PR TITLE
Delete files in .git-ftp-include only if locally deleted

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -631,7 +631,7 @@ add_include_file() {
 			echo "$TARGET" >> "$tmp_include_upload"
 		fi
 	else
-		if [ $(expr substr "$TARGET" ${#TARGET} 1) != '/' ]; then
+		if echo "$TARGET" | grep -v '/$'; then
 			echo "$TARGET" >> "$tmp_include_delete"
 		fi
 	fi

--- a/git-ftp
+++ b/git-ftp
@@ -608,13 +608,17 @@ add_include_files() {
 	grep ':' "$TMP_GITFTP_INCLUDE" | while read LINE; do
 		local TARGET=${LINE%%:*}
 		local SOURCE=${LINE#*:}
-		if [ -d "$TARGET" ]; then
-			find "$TARGET" -type f >> "$tmp_include_upload"
-		elif [ -f "$TARGET" ]; then
-			if grep -Fxq "$SOURCE" "$TMP_GITFTP_UPLOAD"; then
-				echo "$TARGET" >> "$tmp_include_upload"
-			elif grep -Fxq "$SOURCE" "$TMP_GITFTP_DELETE"; then
-				echo "$TARGET" >> "$tmp_include_delete"
+		if grep -Fxq "$SOURCE" "$TMP_GITFTP_UPLOAD" "$TMP_GITFTP_DELETE"; then
+			if [ -e "$TARGET" ]; then
+				if [ -d "$TARGET" ]; then
+					find "$TARGET" -type f >> "$tmp_include_upload"
+				elif [ -f "$TARGET" ]; then
+					echo "$TARGET" >> "$tmp_include_upload"
+				fi
+			else
+				if [ "${TARGET: -1}" != '/' ]; then
+					echo "$TARGET" >> "$tmp_include_delete"
+				fi
 			fi
 		fi
 	done

--- a/git-ftp
+++ b/git-ftp
@@ -616,7 +616,7 @@ add_include_files() {
 					echo "$TARGET" >> "$tmp_include_upload"
 				fi
 			else
-				if [ "${TARGET: -1}" != '/' ]; then
+				if [ $(expr substr "$TARGET" ${#TARGET} 1) != '/' ]; then
 					echo "$TARGET" >> "$tmp_include_delete"
 				fi
 			fi

--- a/git-ftp
+++ b/git-ftp
@@ -605,31 +605,36 @@ add_include_files() {
 	local tmp_include_upload="$TMP_DIR/include_upload_tmp"
 	local tmp_always_include="$TMP_DIR/always_include_tmp"
 	grep -v '^#.*$\|^\s*$' '.git-ftp-include' | tr -d '\r' > "$TMP_GITFTP_INCLUDE"
-	grep '^!' "$TMP_GITFTP_INCLUDE" | sed 's/^!//' > "$tmp_always_include"
-	grep -v '/$' "$tmp_always_include" > "$tmp_include_upload"
-	grep '/$' "$tmp_always_include" | while read TARGET; do
-		find "$TARGET" -type f >> "$tmp_include_upload"
+	grep '^!' "$TMP_GITFTP_INCLUDE" | sed 's/^!//' | while read TARGET; do
+		add_include_file "$TARGET" "$tmp_include_upload" "$tmp_include_delete"
 	done
 	grep ':' "$TMP_GITFTP_INCLUDE" | while read LINE; do
 		local TARGET=${LINE%%:*}
 		local SOURCE=${LINE#*:}
 		if grep -Fxq "$SOURCE" "$TMP_GITFTP_UPLOAD" "$TMP_GITFTP_DELETE"; then
-			if [ -e "$TARGET" ]; then
-				if [ -d "$TARGET" ]; then
-					find "$TARGET" -type f >> "$tmp_include_upload"
-				elif [ -f "$TARGET" ]; then
-					echo "$TARGET" >> "$tmp_include_upload"
-				fi
-			else
-				if [ $(expr substr "$TARGET" ${#TARGET} 1) != '/' ]; then
-					echo "$TARGET" >> "$tmp_include_delete"
-				fi
-			fi
+			add_include_file "$TARGET" "$tmp_include_upload" "$tmp_include_delete"
 		fi
 	done
 	rm -f "$TMP_GITFTP_INCLUDE"
 	add_missing_files "$tmp_include_upload" "$TMP_GITFTP_UPLOAD" "$TMP_GITFTP_DELETE"
 	add_missing_files "$tmp_include_delete" "$TMP_GITFTP_DELETE" "$TMP_GITFTP_UPLOAD"
+}
+
+add_include_file() {
+	local TARGET="${1}"
+	local tmp_include_upload="${2}"
+	local tmp_include_delete="${3}"
+	if [ -e "$TARGET" ]; then
+		if [ -d "$TARGET" ]; then
+			find "$TARGET" -type f >> "$tmp_include_upload"
+		elif [ -f "$TARGET" ]; then
+			echo "$TARGET" >> "$tmp_include_upload"
+		fi
+	else
+		if [ $(expr substr "$TARGET" ${#TARGET} 1) != '/' ]; then
+			echo "$TARGET" >> "$tmp_include_delete"
+		fi
+	fi
 }
 
 add_missing_files() {

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -474,6 +474,26 @@ test_include_push() {
 	assertTrue 'unversioned.txt was not uploaded' "remote_file_exists 'unversioned.txt'"
 }
 
+test_include_push_delete() {
+	echo 'unversioned' > unversioned.txt
+	echo 'unversioned.txt' >> .gitignore
+	echo 'unversioned.txt:test 1.txt' > .git-ftp-include
+	echo 'unversioned.txt:test 2.txt' >> .git-ftp-include
+	echo 'new content' >> 'test 1.txt'
+	git add .
+	git commit -m 'unversioned file unversioned.txt should be uploaded with test 1.txt' -q
+	init=$($GIT_FTP init)
+	git rm 'test 1.txt' -q
+	git commit -m 'the trigger file of unversioned.txt is deleted which deletes the target file' -q
+	push=$($GIT_FTP push)
+	assertTrue 'unversioned.txt was deleted' "remote_file_exists 'unversioned.txt'"
+	echo 'new content' >> 'test 2.txt'
+	rm 'unversioned.txt'
+	git commit -a -m 'the local deletion of unversioned.txt should delete remote file' -q
+	push=$($GIT_FTP push)
+	assertFalse 'unversioned.txt was not deleted' "remote_file_exists 'unversioned.txt'"
+}
+
 test_include_ignore_init() {
 	cd $GIT_PROJECT_PATH
 	echo 'htaccess' > .htaccess


### PR DESCRIPTION
Adresses issue #169.

I'm not sure if the test for a slash as last character works in all shells:

```
 if [ "${TARGET: -1}" != '/' ]; then
   ...
 fi
```