### PR TITLE
Added ability to set a default keychain entry via git config

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -186,6 +186,7 @@ SET DEFAULTS
 	. git config git-ftp.cacert path/cacert
 	. git config git-ftp.deployedsha1file mySHA1File
 	. git config git-ftp.insecure 1
+	. git config git-ftp.keychain user@example.com
 
 
 SET SCOPE DEFAULTS 
@@ -828,6 +829,8 @@ set_remote_cacert() {
 }
 
 set_remote_password() {
+	KEYCHAIN_USER="$(get_config keychain)"
+	[ -z "$KEYCHAIN_USER" ] || USE_KEYCHAIN=1
 	[ -z "$REMOTE_PASSWD" ] && [ $USE_KEYCHAIN -eq 1 ] && get_keychain_password "$KEYCHAIN_USER"
 	[ -z "$REMOTE_PASSWD" ] && REMOTE_PASSWD="$(get_config password)"
 }

--- a/man/git-ftp.1.md
+++ b/man/git-ftp.1.md
@@ -144,7 +144,7 @@ But, there is not just FTP. Supported protocols are:
 
 Don't repeat yourself. Setting config defaults for git-ftp in .git/config
 
-	$ git config git-ftp.<(url|user|password|syncroot|cacert)> <value>
+	$ git config git-ftp.<(url|user|password|syncroot|cacert|keychain)> <value>
 
 Everyone likes examples:
 
@@ -156,6 +156,7 @@ Everyone likes examples:
 	$ git config git-ftp.deployedsha1file mySHA1File
 	$ git config git-ftp.insecure 1
 	$ git config git-ftp.key ~/.ssh/id_rsa
+	$ git config git-ftp.keychain user@example.com
 
 After setting those defaults, push to *john@ftp.example.com* is as simple as
 


### PR DESCRIPTION
git-ftp now tries to read the `git config git-ftp.keychain` entry and use it to retrieve username and password for the FTP server