### PR TITLE
Makefiles: allow custom bindir and mandir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,52 +1,52 @@
 #! /usr/bin/make -f
 SHELL=/bin/sh
 
-DESTDIR?=/usr/local
-prefix?=${DESTDIR}
+prefix ?=/usr/local
+bindir ?=${prefix}/bin
+mandir ?=${prefix}/man/man1
 
 # files that need mode 755
 EXEC_FILES=git-ftp
 
 # files that need mode 644
-MAN_FILE=man1/git-ftp.1
+MAN_FILE=git-ftp.1
 
 all:
 	@echo "usage: make install     -> installs git-ftp only"
 	@echo "       make install-man -> installs man pages only"
-	@echo "       make install-all -> installs git-ftp and man pages"	
+	@echo "       make install-all -> installs git-ftp and man pages"
 	@echo "       make uninstall"
 	@echo "       make uninstall-man"
 	@echo "       make uninstall-all"
 	@echo "       make clean"
 
 install:
-	install -d -m 0755 $(prefix)/bin
-	install -m 0755 $(EXEC_FILES) $(prefix)/bin
+	install -d -m 0755 $(bindir)
+	install -m 0755 $(EXEC_FILES) $(bindir)
 
 install-man:
-	install -d -m 0755 $(prefix)/man
+	mkdir -p $(mandir)
 	cd man && \
 	make man && \
-	install -d -m 0755 $(prefix)/man/man1 && \
-	install -m 0644 $(MAN_FILE) $(prefix)/man/man1 && \
-	mandb $(prefix)/man/man1
+	install -m 0644 $(MAN_FILE) $(mandir)
+ifneq "$(shell uname -s)" "Darwin"
+	mandb $(mandir)
+endif
 
 install-all: install install-man
 
 uninstall:
-	test -d $(prefix)/bin && \
-	cd $(prefix)/bin && \
+	test -d $(bindir) && \
+	cd $(bindir) && \
 	rm -f $(EXEC_FILES)
 
 uninstall-man:
-	test -d $(prefix)/man && \
-	cd $(prefix)/man && \
-	rm -f $(MAN_FILE)
-	mandb -f $(prefix)/man/$(MAN_FILE)
-	rmdir --ignore-fail-on-non-empty $(prefix)/man/man1
+	test -d $(mandir) && rm -rf $(mandir)
+ifneq "$(shell uname -s)" "Darwin"
+	mandb -f $(mandir)/$(MAN_FILE)
+endif
 
 uninstall-all: uninstall uninstall-man
 
 clean:
 	cd man && make clean
-

--- a/man/Makefile
+++ b/man/Makefile
@@ -1,19 +1,17 @@
 SHELL=/bin/sh
 
 # files that need mode 644
-MAN_FILE=man1/git-ftp.1
+MAN_FILE=git-ftp.1
 HTML_FILE=html/git-ftp.html
 
 all:
 	@echo "usage: make man"
 	@echo "       make clean"
 man:
-	install -d -m 0755 man1
 	pandoc -s \
 		-w man git-ftp.1.md \
 		-o  $(MAN_FILE)
 man-ronn:
-	install -d -m 0755 man1
 	ronn --roff --pipe \
 		git-ftp.1.md \
 		> $(MAN_FILE)
@@ -24,5 +22,3 @@ html:
 clean:
 	rm -f $(MAN_FILE)
 	rm -f $(HTML_FILE)
-	rmdir man1 --ignore-fail-on-non-empty
-


### PR DESCRIPTION
Also:
- ~~change the default mandir to $(prefix)/share/man/man1~~
- allow `make install-man` to succeed on systems without mandb (such as Mac OS X)