### PR TITLE
Forcing add_include_files to be called before the IGNORE_DEPLOYED check

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Kang 'ikasty' Dae Youn <mail.ikasty@gmail.com>
 Maikel Linke <mkllnk@web.de>
 Marc Addeo <marcaddeo@gmail.com>
 Hugo Laloge <hugo.laloge@yahoo.fr>
+Lucas Chain <github.com/lucaschain>

--- a/git-ftp
+++ b/git-ftp
@@ -552,13 +552,13 @@ set_deployed_sha1() {
 set_changed_files() {
 	set_tmp
 	# Get raw list of files
+	add_include_files
 	if [ $IGNORE_DEPLOYED -ne 0 ]; then
 		write_log "Taking all files.";
 		list_all_files
 	else
 		list_changed_files || return
 	fi
-	add_include_files
 	filter_ignore_files "$TMP_GITFTP_UPLOAD" "$TMP_GITFTP_DELETE"
 	if [ -s "$TMP_GITFTP_UPLOAD" ] || [ -s "$TMP_GITFTP_DELETE" ]; then
 		write_log "Having files to sync.";


### PR DESCRIPTION
This way, we can force the deployment of git-ftp-included files only