### PR TITLE
Suppress submodule status error message of git v2.7

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -229,7 +229,7 @@ has() {
 }
 
 cache_git_submodules() {
-	GIT_SUBMODULES="$(git submodule status -- "$syncroot" | grep -v '^-' | awk '{print $2}')"
+	GIT_SUBMODULES="$(git submodule status -- "$syncroot" 2>/dev/null | grep -v '^-' | awk '{print $2}')"
 }
 
 is_submodule() {


### PR DESCRIPTION
With git v2.7.x, running `git submodule status -- "$syncroot"` on a repository
print the error message "error: pathspec '' did not match any file(s) known to
git." in stderr.

This commit redirect the stderr output to /dev/null to hide the error message
from console output.