### PR TITLE
New option --verbose-commit

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -177,7 +177,6 @@ OPTIONS
 	--insecure		Don't verify server's certificate.
 	--cacert		Specify a <file> as CA certificate store. Useful when a server has got a self-signed certificate.
 	--no-commit		Perform the merge at the and of pull but do not autocommit, to have the chance to inspect and further tweak the merge result before committing.
-	--verbose-commit	Include list of modified files in commit message after the pull.
 	--disable-epsv		Tell curl to disable the use of the EPSV command when doing passive FTP transfers. Curl will normally always first attempt to use EPSV before PASV, but with this option, it will not try using EPSV.
 	--version		Prints version.
 
@@ -1061,12 +1060,7 @@ fetch_remote() {
 	download_remote_updates
 	[ $DRY_RUN -ne 1 ] || return
 	git add --all
-	local default_commit_message='[git-ftp] remotely untracked modifications'
-	if [ $VERBOSE_COMMIT -eq 1 ] ; then
-		git commit -m "$default_commit_message" -m "`git diff HEAD --name-status`" | grep -v '^#'
-	else
-		git commit -m "$default_commit_message" | grep -v '^#'
-	fi
+	git commit -m '[git-ftp] remotely untracked modifications' -m "`git diff HEAD --name-status`" | grep -v '^#'
 	set_local_sha1
 	upload_local_sha1
 }
@@ -1515,10 +1509,6 @@ do
 		--no-commit)
 			MERGE_ARGS="$MERGE_ARGS --no-commit"
 			write_log "Adding --no-commit to merge arguments: $MERGE_ARGS"
-			;;
-		--verbose-commit)
-			VERBOSE_COMMIT=1
-			write_log "Enabling verbose commit message"
 			;;
 		--disable-epsv)
 			if [ $ACTIVE_MODE -eq 0 ]; then

--- a/git-ftp
+++ b/git-ftp
@@ -177,6 +177,7 @@ OPTIONS
 	--insecure		Don't verify server's certificate.
 	--cacert		Specify a <file> as CA certificate store. Useful when a server has got a self-signed certificate.
 	--no-commit		Perform the merge at the and of pull but do not autocommit, to have the chance to inspect and further tweak the merge result before committing.
+	--verbose-commit	Include list of modified files in commit message after the pull.
 	--disable-epsv		Tell curl to disable the use of the EPSV command when doing passive FTP transfers. Curl will normally always first attempt to use EPSV before PASV, but with this option, it will not try using EPSV.
 	--version		Prints version.
 
@@ -1060,7 +1061,12 @@ fetch_remote() {
 	download_remote_updates
 	[ $DRY_RUN -ne 1 ] || return
 	git add --all
-	git commit -m '[git-ftp] remotely untracked modifications' | grep -v '^#'
+	local default_commit_message='[git-ftp] remotely untracked modifications'
+	if [ $VERBOSE_COMMIT -eq 1 ] ; then
+		git commit -m "$default_commit_message" -m "`git diff HEAD --name-status`" | grep -v '^#'
+	else
+		git commit -m "$default_commit_message" | grep -v '^#'
+	fi
 	set_local_sha1
 	upload_local_sha1
 }
@@ -1509,6 +1515,10 @@ do
 		--no-commit)
 			MERGE_ARGS="$MERGE_ARGS --no-commit"
 			write_log "Adding --no-commit to merge arguments: $MERGE_ARGS"
+			;;
+		--verbose-commit)
+			VERBOSE_COMMIT=1
+			write_log "Enabling verbose commit message"
 			;;
 		--disable-epsv)
 			if [ $ACTIVE_MODE -eq 0 ]; then

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -712,6 +712,7 @@ test_pull() {
 	rtrn=$?
 	assertEquals 0 $rtrn
 	assertTrue ' external file not downloaded' "[ -r 'external.txt' ]"
+	assertTrue ' external file not listed in commit message' "git log | grep 'external.txt'"
 }
 
 test_pull_nothing() {
@@ -760,27 +761,6 @@ test_pull_no_commit() {
 	assertEquals 0 $rtrn
 	assertTrue ' external file not downloaded' "[ -r 'external.txt' ]"
 	assertEquals $LOCAL_SHA1 $(git log -n 1 --pretty=format:%H)
-}
-
-test_pull_verbose_commit() {
-	skip_without lftp
-	cd $GIT_PROJECT_PATH
-	$GIT_FTP init > /dev/null
-	echo 'foreign content' > external.txt
-	curl -T external.txt $CURL_URL/ 2> /dev/null
-	rm external.txt
-	$GIT_FTP pull > /dev/null 2>&1
-	rtrn=$?
-	assertEquals 0 $rtrn
-	assertTrue ' external file not downloaded' "[ -r 'external.txt' ]"
-	assertFalse ' got verbose commit message although option was not set' "git log -1 | grep 'external.txt'"
-	echo 'even more foreign content' > external2.txt
-	curl -T external2.txt $CURL_URL/ 2> /dev/null
-	rm external2.txt
-	$GIT_FTP pull --verbose-commit > /dev/null 2>&1
-	rtrn=$?
-	assertEquals 0 $rtrn
-	assertTrue ' changed file not listed in verbose commit message' "git log -1 | grep 'external2.txt'"
 }
 
 test_pull_dry_run() {

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -762,6 +762,27 @@ test_pull_no_commit() {
 	assertEquals $LOCAL_SHA1 $(git log -n 1 --pretty=format:%H)
 }
 
+test_pull_verbose_commit() {
+	skip_without lftp
+	cd $GIT_PROJECT_PATH
+	$GIT_FTP init > /dev/null
+	echo 'foreign content' > external.txt
+	curl -T external.txt $CURL_URL/ 2> /dev/null
+	rm external.txt
+	$GIT_FTP pull > /dev/null 2>&1
+	rtrn=$?
+	assertEquals 0 $rtrn
+	assertTrue ' external file not downloaded' "[ -r 'external.txt' ]"
+	assertFalse ' got verbose commit message although option was not set' "git log -1 | grep 'external.txt'"
+	echo 'even more foreign content' > external2.txt
+	curl -T external2.txt $CURL_URL/ 2> /dev/null
+	rm external2.txt
+	$GIT_FTP pull --verbose-commit > /dev/null 2>&1
+	rtrn=$?
+	assertEquals 0 $rtrn
+	assertTrue ' changed file not listed in verbose commit message' "git log -1 | grep 'external2.txt'"
+}
+
 test_pull_dry_run() {
 	skip_without lftp
 	cd $GIT_PROJECT_PATH


### PR DESCRIPTION
Includes a list of modified files in the commit message after the pull.

The verbose commit message contains the output of `git diff HEAD --name-status`:
```
[git-ftp] remotely untracked modifications

A	uploads/new_image.jpg
D	data/removed_file.dat
M	pages/modified_content.txt
```

My personal use case is an FTP-hosted website running on [Grav](http://getgrav.org/) with user-generated content stored as plaintext Markdown files that I keep track of with a daily cronjob à la `git ftp pull && git push`. With verbose commit messages I can see the changes at a glance in my Gitlab repository overview and don't have to manually open each commit to see what files (=pages) have been changed.