### PR TITLE
fix file renaming

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -391,7 +391,7 @@ upload_file() {
 upload_file_buffered() {
 	local SRC_FILE="$1"
 	local DEST_FILE="${SRC_FILE#$SYNCROOT}"
-	local ENC_DEST_FILE="${DEST_FILE//#/%23}"
+	local ENC_DEST_FILE="${DEST_FILE//#}"
 	echo "-T \"./$SRC_FILE\"
 url = \"$REMOTE_BASE_URL/${REMOTE_PATH}${ENC_DEST_FILE}\"" >> "$TMP_CURL_UPLOAD_FILE"
 }


### PR DESCRIPTION
this change seems to fix a bug that causes the adding of a hashtag sign "#" before the name of all the uploaded files , happens in windows + MINGW32

![hashtag](https://cloud.githubusercontent.com/assets/8279601/15024581/53a5b76e-122d-11e6-9d6b-fce2f6934015.JPG)
