### PR TITLE
Pull action only checking files based on diff

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -164,7 +164,7 @@ OPTIONS
 	-b, --branch		Git branch to push
 	-s, --scope		Using a scope (e.g. dev, production, testing).
 	-D, --dry-run		Dry run: Does not upload anything.
-	-a, --all		Uploads or pull all files, ignores deployed SHA1 hash.
+	-a, --all		Uploads all files, ignores deployed SHA1 hash.
 	-c, --commit		Sets SHA1 hash of last deployed commit by option.
 	-A, --active		Use FTP active mode.
 	-l, --lock		Enable/Disable remote locking.
@@ -177,6 +177,7 @@ OPTIONS
 	--insecure		Don't verify server's certificate.
 	--cacert		Specify a <file> as CA certificate store. Useful when a server has got a self-signed certificate.
 	--no-commit		Perform the merge at the and of pull but do not autocommit, to have the chance to inspect and further tweak the merge result before committing.
+	--changed-only	During the ftp mirror operation during a pull command, consider only the files changed since the deployed commit.
 	--no-verify		Bypass the pre-ftp-push hook.
 	--disable-epsv		Tell curl to disable the use of the EPSV command when doing passive FTP transfers. Curl will normally always first attempt to use EPSV before PASV, but with this option, it will not try using EPSV.
 	--version		Prints version.
@@ -998,8 +999,8 @@ download_remote_updates () {
 
 	include=""
 	ignoreall=""
-	# For a pull command, by default, mirror only the files from the diff between the FTP commit and the current branch/commit
-	if [ ! -z $CURRENT_BRANCH ] && [ $IGNORE_DEPLOYED -ne 1 ]; then
+	# Mirror only the files from the diff between the FTP commit and the current branch/commit
+	if [ $PULL_CHANGED_ONLY -eq 1 ] && [ ! -z $CURRENT_BRANCH ]; then
 		ignoreall=" --exclude '.*' --exclude '.*/'"
 		include=`git diff $CURRENT_BRANCH --name-only | awk 'NF' | sed 's/$/"/' | sed 's/^/ --include "/' | tr -d '\r\n'`
 		filenames=`git diff $CURRENT_BRANCH --name-only | sed 's/^/\t/' `
@@ -1534,6 +1535,10 @@ do
 		--no-commit)
 			MERGE_ARGS="$MERGE_ARGS --no-commit"
 			write_log "Adding --no-commit to merge arguments: $MERGE_ARGS"
+			;;
+		--changed-only)
+			PULL_CHANGED_ONLY=1
+			write_log "Pulling only changed files."
 			;;
 		--disable-epsv)
 			if [ $ACTIVE_MODE -eq 0 ]; then

--- a/git-ftp
+++ b/git-ftp
@@ -68,6 +68,7 @@ TMP_GITFTP_INCLUDE=""
 declare -a CURL_ARGS
 declare -i VERBOSE=0
 declare -i IGNORE_DEPLOYED=0
+declare -i PULL_CHANGED_ONLY=0
 declare -i DRY_RUN=0
 declare -i FORCE=0
 declare -i ENABLE_REMOTE_LCK=0
@@ -1000,10 +1001,10 @@ download_remote_updates () {
 	include=""
 	ignoreall=""
 	# Mirror only the files from the diff between the FTP commit and the current branch/commit
-	if [ $PULL_CHANGED_ONLY -eq 1 ] && [ ! -z $CURRENT_BRANCH ]; then
+	if [ "$PULL_CHANGED_ONLY" -eq 1 ] && [ -n "$CURRENT_BRANCH" ]; then
 		ignoreall=" --exclude '.*' --exclude '.*/'"
-		include=`git diff $CURRENT_BRANCH --name-only | awk 'NF' | sed 's/$/"/' | sed 's/^/ --include "/' | tr -d '\r\n'`
-		filenames=`git diff $CURRENT_BRANCH --name-only | sed 's/^/\t/' `
+		include="$(git diff "$CURRENT_BRANCH" --name-only | awk 'NF' | sed 's/$/"/' | sed 's/^/ --include "/' | tr -d '\r\n')"
+		filenames="$(git diff $CURRENT_BRANCH --name-only | sed 's/^/\t/')"
 		write_log "Only pulling diff files:\n$filenames"
 	fi
 

--- a/git-ftp
+++ b/git-ftp
@@ -206,7 +206,7 @@ SET DEFAULTS
 	. git config git-ftp.keychain user@example.com
 
 
-SET SCOPE DEFAULTS 
+SET SCOPE DEFAULTS
 	e.g. your scope is 'testing'
 	. git config git-ftp.testing.url ftp.example.local
 
@@ -796,7 +796,7 @@ set_submodule_args() {
 handle_remote_protocol_options() {
 	if [ "$REMOTE_PROTOCOL" = "sftp" ]; then
 		set_sftp_config
-		
+
 		if [ ! -z "$CURL_PRIVATE_KEY" ]; then
 			write_log "Using ssh private key file $CURL_PRIVATE_KEY"
 			if [ -z "$CURL_PUBLIC_KEY" ]; then
@@ -806,7 +806,7 @@ handle_remote_protocol_options() {
 			write_log "Using ssh public key file $CURL_PUBLIC_KEY"
 			REMOTE_CMD_OPTIONS="$REMOTE_CMD_OPTIONS --key $CURL_PRIVATE_KEY --pubkey $CURL_PUBLIC_KEY"
 		fi
-		
+
 		# SFTP uses a different remove command and uses absolute paths
 		REMOTE_DELETE_CMD="rm /"
 	fi
@@ -932,7 +932,7 @@ set_remotes() {
 		write_log "No password is set."
 	else
 		write_log "Password is set."
-	fi 
+	fi
 
 	local REMOTE_LOGIN=''
 	local DISPLAY_LOGIN=''
@@ -958,7 +958,7 @@ set_remotes() {
 
 	set_remote_cacert
 	write_log "CACert is '$REMOTE_CACERT'."
-	
+
 	set_curl_insecure
 	write_log "Insecure is '$CURL_INSECURE'."
 }
@@ -998,10 +998,12 @@ download_remote_updates () {
 		mirror_options="$mirror_options -v"
 	fi
 
+	delete="--delete"
 	include=""
 	ignoreall=""
 	# Mirror only the files from the diff between the FTP commit and the current branch/commit
 	if [ "$PULL_CHANGED_ONLY" -eq 1 ] && [ -n "$CURRENT_BRANCH" ]; then
+		delete=""
 		ignoreall=" --exclude '.*' --exclude '.*/'"
 		include="$(git diff "$CURRENT_BRANCH" --name-only | awk 'NF' | sed 's/$/"/' | sed 's/^/ --include "/' | tr -d '\r\n')"
 		filenames="$(git diff $CURRENT_BRANCH --name-only | sed 's/^/\t/')"
@@ -1014,7 +1016,7 @@ download_remote_updates () {
 	fi
 	ignore+="--exclude=^\.git/ --exclude=^\.git-ftp\.log --exclude=^\.git-ftp-ignore"
 
-	lftp_command="set ftp:list-options -a && mirror$mirror_options --delete $ignoreall $include $ignore . $SYNCROOT && wait all && exit"
+	lftp_command="set ftp:list-options -a && mirror$mirror_options $delete $ignoreall $include $ignore . $SYNCROOT && wait all && exit"
 	lftp $LFTP_OPTIONS -e "$lftp_command" -u "${REMOTE_USER},${REMOTE_PASSWD}" ${REMOTE_PROTOCOL}://${REMOTE_HOST}/${REMOTE_PATH}
 }
 

--- a/git-ftp
+++ b/git-ftp
@@ -164,7 +164,7 @@ OPTIONS
 	-b, --branch		Git branch to push
 	-s, --scope		Using a scope (e.g. dev, production, testing).
 	-D, --dry-run		Dry run: Does not upload anything.
-	-a, --all		Uploads all files, ignores deployed SHA1 hash.
+	-a, --all		Uploads or pull all files, ignores deployed SHA1 hash.
 	-c, --commit		Sets SHA1 hash of last deployed commit by option.
 	-A, --active		Use FTP active mode.
 	-l, --lock		Enable/Disable remote locking.
@@ -307,7 +307,7 @@ set_deployed_sha1_file() {
 # Simple log func
 write_log() {
 	if [ $VERBOSE -eq 1 ]; then
-		echo "$(date): $1"
+		echo -e "$(date): $1"
 	else
 		if [ -n "$LOG_CACHE" ]; then
 			LOG_CACHE="$LOG_CACHE\n$(date): $1"
@@ -347,7 +347,7 @@ print_error_and_die() {
 # Simple info printer
 print_info() {
 	if [ $VERBOSE -eq 0 ]; then
-		echo "$1"
+		echo -e "$1"
 	else
 		write_log "$1"
 	fi
@@ -996,12 +996,24 @@ download_remote_updates () {
 		mirror_options="$mirror_options -v"
 	fi
 
+	include=""
+	ignoreall=""
+	# For a pull command, by default, mirror only the files from the diff between the FTP commit and the current branch/commit
+	if [ ! -z $CURRENT_BRANCH ] && [ $IGNORE_DEPLOYED -ne 1 ]; then
+		ignoreall=" --exclude '.*' --exclude '.*/'"
+		include=`git diff $CURRENT_BRANCH --name-only | awk 'NF' | sed 's/$/"/' | sed 's/^/ --include "/' | tr -d '\r\n'`
+		filenames=`git diff $CURRENT_BRANCH --name-only | sed 's/^/\t/' `
+		write_log "Only pulling diff files:\n$filenames"
+	fi
+
 	ignore=""
 	if [ -f '.git-ftp-ignore' ]; then
-		ignore=`grep -v ^# .git-ftp-ignore | awk 'NF' | sed 's/^/--exclude /'`
-		ignore=`echo $ignore | tr -d '\r'`
+		ignore=`grep -v ^# .git-ftp-ignore | awk 'NF' | sed 's/^/ --exclude /' | tr -d '\r\n'`
 	fi
-	lftp $LFTP_OPTIONS -e "set ftp:list-options -a && mirror$mirror_options $ignore --delete --exclude=^\.git/ --exclude=^\.git-ftp\.log --exclude=^\.git-ftp-ignore . $SYNCROOT && wait all && exit" -u "${REMOTE_USER},${REMOTE_PASSWD}" ${REMOTE_PROTOCOL}://${REMOTE_HOST}/${REMOTE_PATH}
+	ignore+="--exclude=^\.git/ --exclude=^\.git-ftp\.log --exclude=^\.git-ftp-ignore"
+
+	lftp_command="set ftp:list-options -a && mirror$mirror_options --delete $ignoreall $include $ignore . $SYNCROOT && wait all && exit"
+	lftp $LFTP_OPTIONS -e "$lftp_command" -u "${REMOTE_USER},${REMOTE_PASSWD}" ${REMOTE_PROTOCOL}://${REMOTE_HOST}/${REMOTE_PATH}
 }
 
 set_scope() {

--- a/man/git-ftp.1.md
+++ b/man/git-ftp.1.md
@@ -80,7 +80,7 @@ different and handles only those files. That saves time and bandwidth.
 :	FTP password from KeyChain (Mac OS X only).
 
 `-a`, `--all`
-:	Uploads (or pull) all files of current Git checkout (or FTP) disregarding commit changes.
+:	Uploads all files of current Git checkout.
 
 `-A`, `--active`
 :	Uses FTP active mode.
@@ -143,6 +143,9 @@ different and handles only those files. That saves time and bandwidth.
 
 `--no-commit`
 :	Stop while merging downloaded changes during the pull action.
+
+`--changed-only`
+: During the ftp mirror operation during a pull command, consider only the files changed since the deployed commit.
 
 `--no-verify`
 :	Bypass the pre-ftp-push hook. See **HOOKS** section.

--- a/man/git-ftp.1.md
+++ b/man/git-ftp.1.md
@@ -80,7 +80,7 @@ different and handles only those files. That saves time and bandwidth.
 :	FTP password from KeyChain (Mac OS X only).
 
 `-a`, `--all`
-:	Uploads all files of current Git checkout.
+:	Uploads (or pull) all files of current Git checkout (or FTP) disregarding commit changes.
 
 `-A`, `--active`
 :	Uses FTP active mode.

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -779,7 +779,7 @@ test_pull() {
 	echo 'own content' > internal.txt
 	git add . > /dev/null 2>&1
 	git commit -a -m "local modification" > /dev/null 2>&1
-	$GIT_FTP pull --all > /dev/null 2>&1
+	$GIT_FTP pull > /dev/null 2>&1
 	rtrn=$?
 	assertEquals 0 $rtrn
 	assertTrue ' external file not downloaded' "[ -r 'external.txt' ]"
@@ -790,7 +790,7 @@ test_pull_nothing() {
 	skip_without lftp
 	cd $GIT_PROJECT_PATH
 	$GIT_FTP init > /dev/null
-	$GIT_FTP pull --all > /dev/null 2>&1
+	$GIT_FTP pull > /dev/null 2>&1
 	assertEquals 0 $?
 }
 
@@ -808,7 +808,7 @@ test_pull_branch() {
 	echo '1' > version.txt
 	git add -A .
 	git commit -m 'branch modification' > /dev/null 2>&1
-	$GIT_FTP pull --all > /dev/null 2>&1
+	$GIT_FTP pull > /dev/null 2>&1
 	rtrn=$?
 	assertEquals 0 $rtrn
 	assertTrue ' external file not downloaded' "[ -r 'external.txt' ]"
@@ -827,7 +827,7 @@ test_pull_no_commit() {
 	git add . > /dev/null 2>&1
 	git commit -a -m "local modification" > /dev/null 2>&1
 	LOCAL_SHA1=$(git log -n 1 --pretty=format:%H)
-	$GIT_FTP pull --all --no-commit > /dev/null 2>&1
+	$GIT_FTP pull --no-commit > /dev/null 2>&1
 	rtrn=$?
 	assertEquals 0 $rtrn
 	assertTrue ' external file not downloaded' "[ -r 'external.txt' ]"
@@ -842,7 +842,7 @@ test_pull_dry_run() {
 	echo 'own content' > internal.txt
 	git add . > /dev/null 2>&1
 	git commit -a -m "local modification" > /dev/null 2>&1
-	pull=$($GIT_FTP pull --all --dry-run 2> /dev/null)
+	pull=$($GIT_FTP pull --dry-run 2> /dev/null)
 	assertEquals 0 $?
 	assertTrue ' external file downloaded' "[ ! -e 'external.txt' ]"
 	assertFalse "$pull" "echo \"$pull\" | grep 'Last deployment changed to '"
@@ -858,7 +858,7 @@ test_pull_untracked() {
 	echo 'internal.txt' >> .gitignore
 	git add . > /dev/null 2>&1
 	git commit -a -m "ignore some file" > /dev/null 2>&1
-	pull=$($GIT_FTP pull --all 2> /dev/null)
+	pull=$($GIT_FTP pull 2> /dev/null)
 	assertEquals 0 $?
 	assertTrue 'internal.txt is missing' "[ -f internal.txt ]"
 	assertEquals '' "$(git log -- 'internal.txt')"
@@ -871,7 +871,7 @@ test_pull_stash() {
 	echo 'foreign content' | curl -T - $CURL_URL/external.txt 2> /dev/null
 	echo 'own content' > internal.txt
 	git stash -u -q
-	pull=$($GIT_FTP pull --all 2> /dev/null)
+	pull=$($GIT_FTP pull 2> /dev/null)
 	assertEquals 0 $?
 	stash_count="$(git stash list | wc -l)"
 	stash_count=$((stash_count+0)) # trims whitespaces produced by wc on OSX
@@ -880,7 +880,7 @@ test_pull_stash() {
 	assertEquals '' "$(git log -- 'internal.txt')"
 }
 
-test_pull_diffonly() {
+test_pull_changedonly() {
 	skip_without lftp
 	cd $GIT_PROJECT_PATH
 	echo 'foreign content' > external.txt
@@ -898,7 +898,7 @@ test_pull_diffonly() {
 	echo 'local modification\nown content' > locallyremotely_modified.txt
 	git add . > /dev/null 2>&1
 	git commit -a -m "local modification" > /dev/null 2>&1
-	$GIT_FTP pull > /dev/null 2>&1
+	$GIT_FTP pull --changed-only > /dev/null 2>&1
 	rtrn=$?
 	assertEquals 0 $rtrn
 	assertFalse ' external file downloaded' "[ -r 'external.txt' ]"


### PR DESCRIPTION
Hi.

Here is a pull request concerning this idea https://github.com/git-ftp/git-ftp/issues/279

I made it the default behavior of the pull command; old behavior is achieved by adding the --all parameter

So, basically, instead of checking all the files on the FTP server it checks just for the modified files.
Modified files are determined by a git diff beetween the FTP commit and the current branch/commit.

We could handle things differently, I just quickly put it this way because I needed it asap.
I took some extra time to edit the tests and docs.
