### PR TITLE
Test for parameters before adding them to submodules

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -752,12 +752,15 @@ submodule_catchup() {
 }
 
 set_submodule_args() {
-	# Duplicate the current required parameters if set
-	args="" 
-	if [ -z "$REMOTE_USER" ]; then
+	# Empty array args
+	args=()
+	
+	# If no REMOTE_USER or no REMOTE_PASS then don't add parameters
+	# Probabably using .netrc 
+	if [ ! -z "$REMOTE_USER" ]; then
 		args+=(--user "$REMOTE_USER")
 	fi
-	if [ -z "$REMOTE_PASSWD" ]; then
+	if [ ! -z "$REMOTE_PASSWD" ]; then
 		args+=(--passwd "$REMOTE_PASSWD")
 	fi
 

--- a/git-ftp
+++ b/git-ftp
@@ -752,8 +752,14 @@ submodule_catchup() {
 }
 
 set_submodule_args() {
-	# Duplicate the current required parameters
-	args=(--user "$REMOTE_USER" --passwd "$REMOTE_PASSWD")
+	# Duplicate the current required parameters if set
+	args="" 
+	if [ -z "$REMOTE_USER" ]; then
+		args+=(--user "$REMOTE_USER")
+	fi
+	if [ -z "$REMOTE_PASSWD" ]; then
+		args+=(--passwd "$REMOTE_PASSWD")
+	fi
 
 	# Do not ask any questions for submodules
 	args+=(--force)


### PR DESCRIPTION
Hello, 

When trying to init/push/catchup a project that has submodules and where password is handled by .netrc file i am having the following error message :

`fatal: Too few arguments for option -p.
`

My project's git-ftp.log is uploaded but not the submodules (same with init ...)
Full log : 

```
# git ftp catchup -v
Mon Oct 24 08:15:35 UTC 2016: Host is 'xxxxxxx'.
Mon Oct 24 08:15:35 UTC 2016: User is ''.
Mon Oct 24 08:15:35 UTC 2016: No password is set.
Mon Oct 24 08:15:35 UTC 2016: Protocol not set, using default protocol ftp://.
Mon Oct 24 08:15:35 UTC 2016: Path is ''.
Mon Oct 24 08:15:35 UTC 2016: Syncroot is ''.
Mon Oct 24 08:15:35 UTC 2016: The remote sha1 is saved in file '.git-ftp.log'.
Mon Oct 24 08:15:35 UTC 2016: CACert is ''.
Mon Oct 24 08:15:35 UTC 2016: Insecure is ''.
Mon Oct 24 08:15:35 UTC 2016: Uploading commit log to ftp://ftp.cluster003.hosting.ovh.net/.git-ftp.log.
######################################################################## 100.0%
Mon Oct 24 08:15:35 UTC 2016: Last deployment changed to af0fd470b37d7eac3f264f046da9d8b8024f54e5.
Mon Oct 24 08:15:35 UTC 2016: Submodules are vendor/mediaelement
Mon Oct 24 08:15:35 UTC 2016: Catching up submodule vendor/mediaelement.
fatal: Too few arguments for option -p.
```

The problem comes from this line : 
https://github.com/git-ftp/git-ftp/blob/master/git-ftp#L756

Where usename and password are added without testing.
