### PR TITLE
SFTP without pubkey

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -830,7 +830,11 @@ handle_remote_protocol_options() {
 				CURL_PUBLIC_KEY="$CURL_PRIVATE_KEY.pub"
 			fi
 			write_log "Using ssh public key file $CURL_PUBLIC_KEY"
-			REMOTE_CMD_OPTIONS="$REMOTE_CMD_OPTIONS --key $CURL_PRIVATE_KEY --pubkey $CURL_PUBLIC_KEY"
+			if [ "$CURL_INSECURE" = "1" ] && [ ! -f "$CURL_PUBLIC_KEY" ]; then
+				REMOTE_CMD_OPTIONS="$REMOTE_CMD_OPTIONS --key $CURL_PRIVATE_KEY"
+			else
+				REMOTE_CMD_OPTIONS="$REMOTE_CMD_OPTIONS --key $CURL_PRIVATE_KEY --pubkey $CURL_PUBLIC_KEY"
+			fi
 		fi
 
 		# SFTP uses a different remove command and uses absolute paths

--- a/git-ftp
+++ b/git-ftp
@@ -825,8 +825,8 @@ handle_remote_protocol_options() {
 
 		if [ ! -z "$CURL_PRIVATE_KEY" ]; then
 			write_log "Using ssh private key file $CURL_PRIVATE_KEY"
-			if [ -z "$CURL_PUBLIC_KEY" ]; then
-				# If public key is not specified, use private key with .pub extension
+			if [ -z "$CURL_PUBLIC_KEY" ] && [ -f "$CURL_PRIVATE_KEY.pub" ]; then
+				# If public key is not specified, use private key with .pub extension if exists
 				CURL_PUBLIC_KEY="$CURL_PRIVATE_KEY.pub"
 			fi
 			write_log "Using ssh public key file $CURL_PUBLIC_KEY"


### PR DESCRIPTION
After I started this pull request, I noticed 3949cf3718b4ffc4aaa5452861574bdca6f962dc.

I figured I might as well submit the request anyways. This fixes #319 & potentially #320?

In order for this to work, it will require the `--insecure` option. This would also retain backwards compatibility with auto adding the .pub extension to the private key if it was omitted when using `--key`