### PR TITLE
Separate lftp excludes properly (fixes #377)

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -1078,7 +1078,7 @@ download_remote_updates () {
 
 	ignore=""
 	if [ -f '.git-ftp-ignore' ]; then
-		ignore="$(grep -v '^#' .git-ftp-ignore | awk 'NF' | sed 's/^\(.*\)$/ --exclude "\1"/' | tr -d '\r\n')"
+		ignore="$(grep -v '^#' .git-ftp-ignore | awk 'NF' | sed 's/^\(.*\)$/--exclude "\1" /' | tr -d '\r\n')"
 	fi
 	ignore+="--exclude=^\.git/ --exclude=^\.git-ftp\.log --exclude=^\.git-ftp-ignore"
 


### PR DESCRIPTION
Otherwise the last exclude item generated from .git-ftp-ignore
merges with --exclude=^\.git/, invalidating both.