### PR TITLE
Avoid git warning: empty strings as pathspecs

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -623,7 +623,7 @@ set_changed_files() {
 }
 
 list_all_files() {
-	git ls-files -z -- "$SYNCROOT" > "$TMP_GITFTP_UPLOAD"
+	git ls-files -z -- "${SYNCROOT:-.}" > "$TMP_GITFTP_UPLOAD"
 	touch "$TMP_GITFTP_DELETE"
 }
 


### PR DESCRIPTION
Since git 2.11.0 the ls-files subcommand behaves like:

$ git ls-files -- ""
warning: empty strings as pathspecs will be made invalid in upcoming releases. please use . instead if you meant to match all paths
[...]

We'd better follow the advice.