### PR TITLE
Fixed post hook reference to deployed SHA1

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -52,6 +52,7 @@ KEYCHAIN_USER=""
 KEYCHAIN_HOST=""
 DEPLOYED_SHA1_FILE=".git-ftp.log"
 DEPLOYED_SHA1=""
+PREV_DEPLOYED_SHA1=""
 LOCAL_SHA1=""
 SYNCROOT=""
 SNAPSHOT_DIR=""
@@ -479,6 +480,7 @@ upload_local_sha1() {
 		check_exit_status "Could not upload." "$ERROR_UPLOAD"
 	fi
 	print_info "Last deployment changed from $DEPLOYED_SHA1 to $LOCAL_SHA1.";
+	PREV_DEPLOYED_SHA1="$DEPLOYED_SHA1"
 	DEPLOYED_SHA1="$LOCAL_SHA1"
 }
 
@@ -495,8 +497,8 @@ post_push_hook() {
 	hook='.git/hooks/post-ftp-push'
 	if [ -e "$hook" ]; then
 		scope="${SCOPE:-$REMOTE_HOST}"
-		write_log "Trigger post-ftp-push hook with: $scope, $REMOTE_URL, $LOCAL_SHA1, $DEPLOYED_SHA1"
-		$hook "$scope" "$REMOTE_URL" "$LOCAL_SHA1" "$DEPLOYED_SHA1"
+		write_log "Trigger post-ftp-push hook with: $scope, $REMOTE_URL, $LOCAL_SHA1, $PREV_DEPLOYED_SHA1"
+		$hook "$scope" "$REMOTE_URL" "$LOCAL_SHA1" "$PREV_DEPLOYED_SHA1"
 	fi
 }
 

--- a/git-ftp
+++ b/git-ftp
@@ -485,20 +485,22 @@ upload_local_sha1() {
 }
 
 pre_push_hook() {
-	hook='.git/hooks/pre-ftp-push'
+	local hook='.git/hooks/pre-ftp-push'
 	if [ "$EXECUTE_HOOKS" -eq 1 -a -e "$hook" ]; then
-		scope="${SCOPE:-$REMOTE_HOST}"
-		write_log "Trigger pre-ftp-push hook with: $scope, $REMOTE_URL, $LOCAL_SHA1, $DEPLOYED_SHA1"
-		print_status | $hook "$scope" "$REMOTE_URL" "$LOCAL_SHA1" "$DEPLOYED_SHA1" || exit "$ERROR_HOOK"
+		local scope="${SCOPE:-$REMOTE_HOST}"
+		local url="$REMOTE_BASE_URL_DISPLAY/$REMOTE_PATH"
+		write_log "Trigger pre-ftp-push hook with: $scope, $url, $LOCAL_SHA1, $DEPLOYED_SHA1"
+		print_status | $hook "$scope" "$url" "$LOCAL_SHA1" "$DEPLOYED_SHA1" || exit "$ERROR_HOOK"
 	fi
 }
 
 post_push_hook() {
-	hook='.git/hooks/post-ftp-push'
+	local hook='.git/hooks/post-ftp-push'
 	if [ -e "$hook" ]; then
-		scope="${SCOPE:-$REMOTE_HOST}"
-		write_log "Trigger post-ftp-push hook with: $scope, $REMOTE_URL, $LOCAL_SHA1, $PREV_DEPLOYED_SHA1"
-		$hook "$scope" "$REMOTE_URL" "$LOCAL_SHA1" "$PREV_DEPLOYED_SHA1"
+		local scope="${SCOPE:-$REMOTE_HOST}"
+		local url="$REMOTE_BASE_URL_DISPLAY/$REMOTE_PATH"
+		write_log "Trigger post-ftp-push hook with: $scope, $url, $LOCAL_SHA1, $PREV_DEPLOYED_SHA1"
+		$hook "$scope" "$url" "$LOCAL_SHA1" "$PREV_DEPLOYED_SHA1"
 	fi
 }
 

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -1140,8 +1140,7 @@ test_post_push_arguments_first() {
 	hook=".git/hooks/post-ftp-push"
 	echo 'echo "arguments: $1 $2 $3 $4"' > "$hook"
 	scope="$GIT_FTP_HOST$GIT_FTP_PORT"
-	# TODO: the remote URL is missing
-	url=""
+	url="ftp://$GIT_FTP_USER:***@$GIT_FTP_HOST$GIT_FTP_PORT/$REMOTE_PATH/"
 	local_commit="$(git log -n 1 --pretty=format:%H)"
 	remote_commit=""
 	expected="arguments: $scope $url $local_commit $remote_commit"
@@ -1159,8 +1158,7 @@ test_post_push_arguments_repeated() {
 	hook=".git/hooks/post-ftp-push"
 	echo 'echo "arguments: $1 $2 $3 $4"' > "$hook"
 	scope="$GIT_FTP_HOST$GIT_FTP_PORT"
-	# TODO: the remote URL is missing
-	url=""
+	url="ftp://$GIT_FTP_USER:***@$GIT_FTP_HOST$GIT_FTP_PORT/$REMOTE_PATH/"
 	local_commit="$(git log -n 1 --pretty=format:%H)"
 	remote_commit="$first_commit"
 	expected="arguments: $scope $url $local_commit $remote_commit"

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -1136,6 +1136,39 @@ test_post_push() {
 	assertEquals "$message" "$out"
 }
 
+test_post_push_arguments_first() {
+	hook=".git/hooks/post-ftp-push"
+	echo 'echo "arguments: $1 $2 $3 $4"' > "$hook"
+	scope="$GIT_FTP_HOST$GIT_FTP_PORT"
+	# TODO: the remote URL is missing
+	url=""
+	local_commit="$(git log -n 1 --pretty=format:%H)"
+	remote_commit=""
+	expected="arguments: $scope $url $local_commit $remote_commit"
+	chmod +x "$hook"
+	out="$($GIT_FTP init -n)"
+	assertEquals "$expected" "$out"
+}
+
+test_post_push_arguments_repeated() {
+	first_commit="$(git log -n 1 --pretty=format:%H)"
+	$GIT_FTP init -n
+	touch newfile
+	git add . > /dev/null 2>&1
+	git commit -m 'Second commit' -q
+	hook=".git/hooks/post-ftp-push"
+	echo 'echo "arguments: $1 $2 $3 $4"' > "$hook"
+	scope="$GIT_FTP_HOST$GIT_FTP_PORT"
+	# TODO: the remote URL is missing
+	url=""
+	local_commit="$(git log -n 1 --pretty=format:%H)"
+	remote_commit="$first_commit"
+	expected="arguments: $scope $url $local_commit $remote_commit"
+	chmod +x "$hook"
+	out="$($GIT_FTP push -n)"
+	assertEquals "$expected" "$out"
+}
+
 disabled_test_file_named_dash() {
 	cd $GIT_PROJECT_PATH
 	echo "foobar" > -


### PR DESCRIPTION
post-ftp-push is not getting the correct $DEPLOYED_SHA1 because it's overriten in the previous steps. 
This is an attempt to fix this