### PR TITLE
Add config git-ftp.remote-root to docs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ Maikel Linke <mkllnk@web.de>
 Dan Rench <github.com/drench>
 Marc Addeo <marcaddeo@gmail.com>
 Hugo Laloge <hugo.laloge@yahoo.fr>
+Piran Montford <github.com/piranm>

--- a/man/git-ftp.1.md
+++ b/man/git-ftp.1.md
@@ -265,7 +265,7 @@ changes between branch `master` and branch `develop`:
 
 Don't repeat yourself. Setting config defaults for git-ftp in .git/config
 
-	$ git config git-ftp.<(url|user|password|syncroot|cacert|keychain)> <value>
+	$ git config git-ftp.<(url|user|password|syncroot|cacert|keychain|...)> <value>
 
 Everyone likes examples:
 
@@ -278,6 +278,7 @@ Everyone likes examples:
 	$ git config git-ftp.insecure 1
 	$ git config git-ftp.key ~/.ssh/id_rsa
 	$ git config git-ftp.keychain user@example.com
+	$ git config git-ftp.remote-root htdocs
 
 After setting those defaults, push to *john@ftp.example.com* is as simple as
 


### PR DESCRIPTION
Continuation of #163, which only documented the command-line option.

In the general `git config git-ftp` line, added ellipse as not all configs were already included. 