### PR TITLE
Adds an option which allow a post-ftp-push script error to be fatal

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -77,6 +77,7 @@ declare -i ENABLE_REMOTE_LCK=0
 declare -i ACTIVE_MODE=0
 declare -i USE_KEYCHAIN=0
 declare -i EXECUTE_HOOKS=1
+declare -i DISABLE_PPE=1
 declare -a GIT_SUBMODULES
 declare -i AUTO_INIT=0
 
@@ -191,6 +192,7 @@ OPTIONS
 	--no-commit		Perform the merge at the and of pull but do not autocommit, to have the chance to inspect and further tweak the merge result before committing.
 	--changed-only		Download or pull only files changed since the deployed commit while ignoring all other files.
 	--no-verify		Bypass the pre-ftp-push hook.
+	--enable-post-errors	Fails if post-ftp-push hook raises an error
 	--disable-epsv		Tell curl to disable the use of the EPSV command when doing passive FTP transfers. Curl will normally always first attempt to use EPSV before PASV, but with this option, it will not try using EPSV.
 	--auto-init		Automatically run init action when running push action
 	--version		Prints version.
@@ -500,7 +502,7 @@ post_push_hook() {
 		local scope="${SCOPE:-$REMOTE_HOST}"
 		local url="$REMOTE_BASE_URL_DISPLAY/$REMOTE_PATH"
 		write_log "Trigger post-ftp-push hook with: $scope, $url, $LOCAL_SHA1, $PREV_DEPLOYED_SHA1"
-		$hook "$scope" "$url" "$LOCAL_SHA1" "$PREV_DEPLOYED_SHA1"
+		$hook "$scope" "$url" "$LOCAL_SHA1" "$PREV_DEPLOYED_SHA1" || [ "$DISABLE_PPE" -eq 1 ] || exit "$ERROR_HOOK"
 	fi
 }
 
@@ -1650,6 +1652,10 @@ do
 			;;
 		--no-verify)
 			EXECUTE_HOOKS=0
+			shift
+			;;
+		--enable-post-errors)
+			DISABLE_PPE=0
 			shift
 			;;
 		--auto-init)

--- a/git-ftp
+++ b/git-ftp
@@ -77,7 +77,7 @@ declare -i ENABLE_REMOTE_LCK=0
 declare -i ACTIVE_MODE=0
 declare -i USE_KEYCHAIN=0
 declare -i EXECUTE_HOOKS=1
-declare -i DISABLE_PPE=1
+declare -i ENABLE_POST_HOOK_ERRORS=0
 declare -a GIT_SUBMODULES
 declare -i AUTO_INIT=0
 
@@ -502,7 +502,7 @@ post_push_hook() {
 		local scope="${SCOPE:-$REMOTE_HOST}"
 		local url="$REMOTE_BASE_URL_DISPLAY/$REMOTE_PATH"
 		write_log "Trigger post-ftp-push hook with: $scope, $url, $LOCAL_SHA1, $PREV_DEPLOYED_SHA1"
-		$hook "$scope" "$url" "$LOCAL_SHA1" "$PREV_DEPLOYED_SHA1" || [ "$DISABLE_PPE" -eq 1 ] || exit "$ERROR_HOOK"
+		$hook "$scope" "$url" "$LOCAL_SHA1" "$PREV_DEPLOYED_SHA1" || [ "$ENABLE_POST_HOOK_ERRORS" -eq 0 ] || exit "$ERROR_HOOK"
 	fi
 }
 
@@ -1655,7 +1655,7 @@ do
 			shift
 			;;
 		--enable-post-errors)
-			DISABLE_PPE=0
+			ENABLE_POST_HOOK_ERRORS=1
 			shift
 			;;
 		--auto-init)

--- a/man/git-ftp.1.md
+++ b/man/git-ftp.1.md
@@ -168,6 +168,9 @@ different and handles only those files. That saves time and bandwidth.
 `--no-verify`
 :	Bypass the pre-ftp-push hook. See **HOOKS** section.
 
+`--enable-post-errors`
+:	Fails if post-ftp-push raises an error.
+
 `--auto-init`
 :	Automatically run init action when running push action
 

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -1146,6 +1146,8 @@ test_post_push_arguments_first() {
 	expected="arguments: $scope $url $local_commit $remote_commit"
 	chmod +x "$hook"
 	out="$($GIT_FTP init -n)"
+	rtrn=$?
+	assertEquals 0 $rtrn
 	assertEquals "$expected" "$out"
 }
 
@@ -1164,7 +1166,27 @@ test_post_push_arguments_repeated() {
 	expected="arguments: $scope $url $local_commit $remote_commit"
 	chmod +x "$hook"
 	out="$($GIT_FTP push -n)"
+	rtrn=$?
+	assertEquals 0 $rtrn
 	assertEquals "$expected" "$out"
+}
+
+test_post_push_no_fail() {
+	hook=".git/hooks/post-ftp-push"
+	echo 'exit 99' > "$hook"
+	chmod +x "$hook"
+	$GIT_FTP init -n
+	rtrn=$?
+	assertEquals 0 $rtrn
+}
+
+test_post_push_no_fail() {
+	hook=".git/hooks/post-ftp-push"
+	echo 'exit 99' > "$hook"
+	chmod +x "$hook"
+	$GIT_FTP init -n --enable-post-errors
+	rtrn=$?
+	assertEquals 9 $rtrn
 }
 
 disabled_test_file_named_dash() {

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -1180,7 +1180,7 @@ test_post_push_no_fail() {
 	assertEquals 0 $rtrn
 }
 
-test_post_push_no_fail() {
+test_post_push_fail() {
 	hook=".git/hooks/post-ftp-push"
 	echo 'exit 99' > "$hook"
 	chmod +x "$hook"


### PR DESCRIPTION
By default, `post-ftp-push` hook errors doesn't triggers a `git ftp` error.
This makes scripting painful as hook errors are not detectable.
(eg. when one want's to prune the host's cache and when a locked file leads to a hook failure and the CI job ends in success ...)

Hence this new option `--enable-post-errors` which allows error propagation