### PR TITLE
insert space to not mess up lftp exclude options

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -1087,7 +1087,7 @@ download_remote_updates () {
 	if [ -f '.git-ftp-ignore' ]; then
 		ignore="$(grep -v '^#' .git-ftp-ignore | awk 'NF' | sed 's/^\(.*\)$/--exclude-glob "\1" /' | tr -d '\r\n')"
 	fi
-	ignore+="--exclude=^\.git/ --exclude=^\.git-ftp\.log --exclude=^\.git-ftp-ignore"
+	ignore+=" --exclude=^\.git/ --exclude=^\.git-ftp\.log --exclude=^\.git-ftp-ignore"
 
 	lftp_command="set ftp:list-options -a && mirror$mirror_options $delete $ignoreall $include $ignore . $SYNCROOT && wait all && exit"
 	out="$(lftp $LFTP_OPTIONS -e "$lftp_command" -u "${REMOTE_USER},${REMOTE_PASSWD}" "${REMOTE_PROTOCOL}://${REMOTE_HOST}/${REMOTE_PATH}" 2>&1)"


### PR DESCRIPTION
the last line of .git-ftp-ignore as ecclude and var ignore in function download_remote_updates get attached to closely, so that something like --exclude XYZ--exclude ^.git/ happens. The last line and the first ignore statement thereby don't work. Inserting a space at the beginning of the ignore variable solves this problem.