### PR TITLE
Fix check for FTPES protocol support

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -1314,7 +1314,15 @@ check_curl_access() {
 	write_log "Check if curl is functional."
 	command -v curl >/dev/null 2>&1
 	check_exit_status "curl is not available" "$ERROR_DOWNLOAD"
-	curl --version|grep "Protocols"|grep -qw "$REMOTE_PROTOCOL"
+
+	local curl_protocol="$REMOTE_PROTOCOL"
+	# The ftpes protocol is FTP + SSL
+	if [ "$curl_protocol" == "ftpes" ]; then
+		curl_protocol="ftp"
+		curl --version | grep "^Features: " | grep -qw "SSL"
+		check_exit_status "Protocol '$REMOTE_PROTOCOL' not supported by curl" "$ERROR_DOWNLOAD"
+	fi
+	curl --version | grep "^Protocols: " | grep -qw "$curl_protocol"
 	check_exit_status "Protocol '$REMOTE_PROTOCOL' not supported by curl" "$ERROR_DOWNLOAD"
 }
 check_remote_access() {

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -99,6 +99,28 @@ test_prints_version() {
 	assertEquals "git-ftp version $VERSION" "$version"
 }
 
+test_unknown_protocol() {
+	output="$($GIT_FTP_CMD init badProtocol://localhost/ 2>&1)"
+	assertEquals 6 $?
+	assertEquals "fatal: Protocol unknown 'badProtocol://'." "$output"
+}
+
+test_supported_protocol_ftp() {
+	output="$($GIT_FTP_CMD init ftp://localhost/ 2>&1)"
+	status=$?
+	assertNotEquals 6 $status
+	assertNotEquals "fatal: Protocol unknown 'ftp://'." "$output"
+	assertNotEquals "fatal: Protocol 'ftp' not supported by curl, exiting..." "$output"
+}
+
+test_supported_protocol_ftpes() {
+	output="$($GIT_FTP_CMD init ftpes://localhost/ 2>&1)"
+	status=$?
+	assertNotEquals 6 $status
+	assertNotEquals "fatal: Protocol unknown 'ftpes://'." "$output"
+	assertNotEquals "fatal: Protocol 'ftpes' not supported by curl, exiting..." "$output"
+}
+
 test_inits() {
 	init=$($GIT_FTP init)
 	assertEquals 0 $?


### PR DESCRIPTION
Fixes #448.

A check for supported protocols by curl (8bb8f7ccad3b7c1f6cecb6a5ce6367fb05c3cbab) didn't handle FTPES properly.