### PR TITLE
fix: directory creation with SFTP

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -1340,7 +1340,15 @@ check_remote_access() {
 	set_default_curl_options
 	CURL_ARGS+=(--ftp-create-dirs)
 	CURL_ARGS+=("$REMOTE_BASE_URL/$REMOTE_PATH")
-	curl "${CURL_ARGS[@]}" > /dev/null
+	if [ "$REMOTE_PROTOCOL" == "sftp" ]; then
+		curl "${CURL_ARGS[@]}" > /dev/null
+		if [ $? -eq 78 ]; then
+			write_log "Create $REMOTE_PATH"
+			curl "${CURL_ARGS[@]}" -Q "MKDIR $REMOTE_PATH" > /dev/null
+		fi
+	else
+		curl "${CURL_ARGS[@]}" > /dev/null
+	fi
 	check_exit_status "Can't access remote '$REMOTE_BASE_URL_DISPLAY'" "$ERROR_DOWNLOAD"
 }
 


### PR DESCRIPTION
If SFTP is used, the curl parameter `--ftp-create-dirs` has no effect. This means the directory is not created if it does not exist.
Therefore we have to check if we use SFTP and if the access check returns `78` (No such file or directory), we try to send a create command for the directory.

fixes #311
fixes #496

This could also be part of the solution for #295, since it allows to create the directory for submodules during submodule handling.

**Limitations**
According to the [specification of SFTP](https://tools.ietf.org/html/draft-ietf-secsh-filexfer-00#section-6.6) there is no option to create directories recursively. This means that the parent folder of syncroot must exist. Otherwise the create request will fail.
*Example:* If the syncroot is set to `/var/htdocs/html/project/` the directory `/var/htdocs/html/` must exist. If only `/var/htdocs/` exists the command will fail and exit with `curl: (21) mkdir command failed: No such file or directory`