### PR TITLE
fix: error handling with new sftp directory creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 1.6.0-UNRELEASED
+=============
+
+* Change exit code when remote cannot be accessed from 5 (ERROR_DOWNLOAD) to 4 (ERROR_UPLOAD)
+* Fix directory creation with SFTP
+
 Version 1.5.2
 =============
 

--- a/git-ftp
+++ b/git-ftp
@@ -24,7 +24,7 @@
 readonly DEFAULT_PROTOCOL="ftp"
 readonly REMOTE_LCK_FILE="$(basename "$0").lck"
 readonly SYSTEM="$(uname)"
-readonly VERSION='1.5.2'
+readonly VERSION='1.6.0-UNRELEASED'
 
 # ------------------------------------------------------------
 # Defaults

--- a/git-ftp
+++ b/git-ftp
@@ -1340,16 +1340,17 @@ check_remote_access() {
 	set_default_curl_options
 	CURL_ARGS+=(--ftp-create-dirs)
 	CURL_ARGS+=("$REMOTE_BASE_URL/$REMOTE_PATH")
-	if [ "$REMOTE_PROTOCOL" == "sftp" ]; then
-		curl "${CURL_ARGS[@]}" > /dev/null
-		if [ $? -eq 78 ]; then
-			write_log "Create $REMOTE_PATH"
-			curl "${CURL_ARGS[@]}" -Q "MKDIR $REMOTE_PATH" > /dev/null
-		fi
-	else
-		curl "${CURL_ARGS[@]}" > /dev/null
+	curl "${CURL_ARGS[@]}" > /dev/null
+	
+	local EXIT_CODE=$?
+	if [ "$REMOTE_PROTOCOL" == "sftp" ] && [ $EXIT_CODE -eq 78 ]; then
+		write_log "Create $REMOTE_PATH"
+		curl "${CURL_ARGS[@]}" -Q "MKDIR $REMOTE_PATH" > /dev/null
+		EXIT_CODE=$?
 	fi
-	check_exit_status "Can't access remote '$REMOTE_BASE_URL_DISPLAY'" "$ERROR_DOWNLOAD"
+	if [ $EXIT_CODE -ne 0 ]; then
+		print_error_and_die "Can't access remote '$REMOTE_BASE_URL_DISPLAY', exiting..." "$ERROR_UPLOAD"
+	fi
 }
 
 check_deployed_sha1() {

--- a/man/git-ftp.1.md
+++ b/man/git-ftp.1.md
@@ -1,6 +1,6 @@
-% GIT-FTP(1) Git-ftp 1.5.2
+% GIT-FTP(1) Git-ftp 1.6.0-UNRELEASED
 %
-% 2019-04-18
+% 2019-05-06
 
 # NAME
 

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -17,7 +17,7 @@
 # Or you can write it in one line:
 #     TEST_CASES='test_displays_usage' GIT_FTP_PASSWD='s3cr3t' ./git-ftp-test.sh
 
-readonly VERSION='1.5.2'
+readonly VERSION='1.6.0-UNRELEASED'
 
 # ------------------------------------------------------------
 # Constant Exit Error Codes

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -19,6 +19,19 @@
 
 readonly VERSION='1.5.2'
 
+# ------------------------------------------------------------
+# Constant Exit Error Codes
+# ------------------------------------------------------------
+readonly ERROR_USAGE=2
+readonly ERROR_MISSING_ARGUMENTS=3
+readonly ERROR_UPLOAD=4
+readonly ERROR_DOWNLOAD=5
+readonly ERROR_UNKNOWN_PROTOCOL=6
+readonly ERROR_REMOTE_LOCKED=7
+readonly ERROR_GIT=8
+readonly ERROR_HOOK=9
+readonly ERROR_FILESYSTEM=10
+
 suite() {
 	for testcase in ${TEST_CASES}; do
 		suite_addTest "$testcase"
@@ -130,7 +143,7 @@ test_inits() {
 
 test_init_fails() {
 	init=$($GIT_FTP_CMD -v -u wrong_user -p wrong_passwd $GIT_FTP_URL init 2>&1)
-	assertEquals 5 $?
+	assertEquals $ERROR_UPLOAD $?
 	# Not all servers respond correctly
 	#error_count=$(echo "$init" | grep -F 'Access denied' | wc -l)
 	#assertEquals 1 $error_count


### PR DESCRIPTION
Pull request #504 introduced new logic to create directories with sftp.
As mentioned in the [discussion to this](https://github.com/git-ftp/git-ftp/pull/504#discussion_r281009161) the error handling is not perfect. This commit fixes this issue.

At first do the curl request as before bot cache the exit code in a local variable.
The we can check if sftp was used and `$EXIT_CODE` was `78`. If so do the creation stuff. If not check the $EXIT_CODE for other errors.