### PR TITLE
Travis lftp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,23 @@ os:
   - linux
   - osx
 
-addons:
-  homebrew:
-    packages:
-    - lftp
-
 env:
   - LFTP_SUPPORT=0
-  - LFTP_SUPPORT=1
+
+jobs:
+  include:
+    - os: linux
+      env: LFTP_SUPPORT=1
+      addons:
+        apt:
+          packages:
+            - lftp
+    - os: osx
+      env: LFTP_SUPPORT=1
+      addons:
+        homebrew:
+          packages:
+            - lftp
 
 language: sh
 
@@ -17,7 +26,6 @@ install:
   - >
     if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       ./tests/vsftpd-3.0.3.debian7 tests/vsftpd.conf &
-      if [ "$LFTP_SUPPORT" = "1" ]; then sudo apt-get install -y lftp; fi
     fi
   - >
     if [ "$TRAVIS_OS_NAME" = "osx" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ addons:
   homebrew:
     packages:
     - lftp
-    update: true
 
 env:
   - LFTP_SUPPORT=0
@@ -23,7 +22,6 @@ install:
   - >
     if [ "$TRAVIS_OS_NAME" = "osx" ]; then
       ./tests/vsftpd-3.0.3.el_capitan tests/vsftpd.conf &
-      if [ "$LFTP_SUPPORT" = "1" ]; then sudo installer -pkg tests/lftp-4.6.0-0.pkg -target /; fi
     fi
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ os:
   - linux
   - osx
 
+addons:
+  homebrew:
+    packages:
+    - lftp
+    update: true
+
 env:
   - LFTP_SUPPORT=0
   - LFTP_SUPPORT=1


### PR DESCRIPTION
As discussed in #513 this implements a installing mechanism for lftp in Travis CI.

It uses the build matrix feature to install lftp addon on both platforms. So the installation can be removed from the install part of the script.

fixes #513 