### PR TITLE
Enhancement epsv option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Version 1.6.0-UNRELEASED
 * Fix submodule handling
 * Pass insecure-flag to submodules
 * Pass ssh-keys to submodules if used
+* Add support for config `disable-epsv`
+* Allow `true` and `false` for boolean configurations (`insecure`, `disable-epsv`)
 
 Version 1.5.2
 =============

--- a/git-ftp
+++ b/git-ftp
@@ -60,7 +60,7 @@ CURL_PROTOCOL=""
 CURL_INSECURE="0"
 CURL_PUBLIC_KEY=""
 CURL_PRIVATE_KEY=""
-CURL_DISABLE_EPSV=0
+CURL_DISABLE_EPSV="0"
 CURL_PROXY=""
 TMP_DIR=""
 TMP_CURL_UPLOAD_FILE=""
@@ -391,7 +391,7 @@ set_default_curl_options() {
 	if [ $ACTIVE_MODE -eq 1 ]; then
 		CURL_ARGS+=(-P "-")
 	else
-		if [ $CURL_DISABLE_EPSV -eq 1 ]; then
+		if [ "$CURL_DISABLE_EPSV" != "0" ]; then
 			CURL_ARGS+=(--disable-epsv)
 		fi
 	fi
@@ -829,7 +829,7 @@ set_submodule_args() {
 	if [ $ACTIVE_MODE -eq 1 ]; then
 		args+=(--active)
 	else
-		if [ $CURL_DISABLE_EPSV -eq 1 ]; then
+		if [ "$CURL_DISABLE_EPSV" != "0" ]; then
 			args+=(--disable-epsv)
 		fi
 	fi
@@ -1040,6 +1040,9 @@ set_remotes() {
 
 	set_curl_insecure
 	write_log "Insecure is '$CURL_INSECURE'."
+	
+	set_curl_disable_epsv
+	[ "$CURL_DISABLE_EPSV" != "0" ] && write_log "Disable EPSV is '$CURL_DISABLE_EPSV'."
 
 	set_curl_proxy
 	write_log "Proxy is '$CURL_PROXY'."
@@ -1076,6 +1079,11 @@ urlencode() {
 set_curl_insecure() {
 	local config="$(get_config insecure)"
 	[ -n "$config" ] && CURL_INSECURE="$config"
+}
+
+set_curl_disable_epsv() {
+	local config="$(get_config disable-epsv)"
+	[ -n "$config" ] && CURL_DISABLE_EPSV="$config"
 }
 
 set_curl_proxy() {

--- a/git-ftp
+++ b/git-ftp
@@ -246,6 +246,20 @@ is_submodule() {
 	echo "${GIT_SUBMODULES[@]}" | grep -Fxq -- "$1"
 }
 
+boolean() {
+	case "$1" in
+		"true")
+			echo "1"
+			;;
+		"false")
+			echo "0"
+			;;
+		*)
+			echo $1
+			;;
+	esac
+}
+
 ask_for_passwd() {
 	echo -n "Password: "
 	stty -echo > /dev/null 2>&1
@@ -1078,12 +1092,12 @@ urlencode() {
 
 set_curl_insecure() {
 	local config="$(get_config insecure)"
-	[ -n "$config" ] && CURL_INSECURE="$config"
+	[ -n "$config" ] && CURL_INSECURE="$(boolean $config)"
 }
 
 set_curl_disable_epsv() {
 	local config="$(get_config disable-epsv)"
-	[ -n "$config" ] && CURL_DISABLE_EPSV="$config"
+	[ -n "$config" ] && CURL_DISABLE_EPSV="$(boolean $config)"
 }
 
 set_curl_proxy() {

--- a/man/git-ftp.1.md
+++ b/man/git-ftp.1.md
@@ -291,6 +291,7 @@ Everyone likes examples:
 	$ git config git-ftp.key ~/.ssh/id_rsa
 	$ git config git-ftp.keychain user@example.com
 	$ git config git-ftp.remote-root htdocs
+	$ git config git-ftp.disable-epsv 1
 
 After setting those defaults, push to *john@ftp.example.com* is as simple as
 

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -1196,6 +1196,13 @@ test_insecure_from_config() {
 	assertEquals 0 $?
 }
 
+test_insecure_from_config_boolean() {
+	git config git-ftp.insecure true
+	out="$($GIT_FTP init -v 2>/dev/null)"
+	echo "$out" | grep --quiet "Insecure is '1'"
+	assertEquals 0 $?
+}
+
 test_insecure_options() {
 	out="$($GIT_FTP --insecure init -v 2>/dev/null)"
 	echo "$out" | grep --quiet "Insecure is '1'"
@@ -1219,6 +1226,32 @@ test_insecure_submodule() {
 	assertEquals 0 $?
 	count=$(echo "$out" | grep --count "Insecure is '1'")
 	assertEquals 2 $count
+}
+
+test_epsv_defaults_value() {
+	out="$($GIT_FTP init -v 2>/dev/null)"
+	echo "$out" | grep --quiet "Disabling EPSV."
+	assertEquals 1 $?
+}
+
+test_epsv_from_config() {
+	git config git-ftp.disable-epsv 1
+	out="$($GIT_FTP init -v 2>/dev/null)"
+	echo "$out" | grep --quiet "Disable EPSV is '1'."
+	assertEquals 0 $?
+}
+
+test_epsv_from_config_boolean() {
+	git config git-ftp.disable-epsv true
+	out="$($GIT_FTP init -v 2>/dev/null)"
+	echo "$out" | grep --quiet "Disable EPSV is '1'."
+	assertEquals 0 $?
+}
+
+test_epsv_options() {
+	out="$($GIT_FTP --disable-epsv init -v 2>/dev/null)"
+	echo "$out" | grep --quiet "Disable EPSV is '1'."
+	assertEquals 0 $?
 }
 
 test_post_push_arguments_first() {


### PR DESCRIPTION
This pull request adds the option to configure a default value for `disable-epsv` using `git config`.

As well it adds support for `true` and `false` for boolean options, so you can use now:
```sh
$ git config git-ftp.insecure true
$ git config git-ftp.disable-epsv true
```

And some tests for this new features are added.