### PR TITLE
Enhancement scope names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Version 1.6.0-UNRELEASED
 * Change exit code when remote cannot be accessed from 5 (ERROR_DOWNLOAD) to 4 (ERROR_UPLOAD)
 * Fix directory creation with SFTP
 * Fix submodule handling
+* Fix/Add suport for nested branch names by allowing `/` in scope names
 * Pass insecure-flag to submodules
 * Pass ssh-keys to submodules if used
 

--- a/git-ftp
+++ b/git-ftp
@@ -1432,8 +1432,8 @@ do
 			# catch scope
 			if [ "$1" == "add-scope" ] || [ "$1" == "remove-scope" ]; then
 				SCOPE="$2"
-				if ! echo "$SCOPE" | grep -q '^[-0-9a-zA-Z_]*$' ; then
-					print_error_and_die "Invalid scope name." "$ERROR_USAGE"
+				if ! echo "$SCOPE" | grep -q '^[-0-9a-zA-Z_/]*$' ; then
+					print_error_and_die "Invalid scope name. Only these characters are allowed: 0-9 a-z A-Z - _ /" "$ERROR_USAGE"
 				fi
 				shift
 			fi
@@ -1476,8 +1476,8 @@ do
 					fi
 					;;
 			esac
-			if ! echo "$SCOPE" | grep -q '^[-0-9a-zA-Z_]*$' ; then
-				print_error_and_die "Invalid scope name." "$ERROR_USAGE"
+			if ! echo "$SCOPE" | grep -q '^[-0-9a-zA-Z_/]*$' ; then
+				print_error_and_die "Invalid scope name '${SCOPE}'." "$ERROR_USAGE"
 			fi
 			write_log "Using scope $SCOPE if available"
 			;;

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -379,11 +379,11 @@ test_scopes() {
 test_invalid_scope_name() {
 	out=$($GIT_FTP_CMD init -s invalid:scope 2>&1)
 	assertEquals 2 $?
-	assertEquals 'fatal: Invalid scope name.' "$out"
+	assertEquals "fatal: Invalid scope name 'invalid:scope'." "$out"
 
 	out=$($GIT_FTP_CMD add-scope invalid:scope 2>&1)
 	assertEquals 2 $?
-	assertEquals 'fatal: Invalid scope name.' "$out"
+	assertEquals 'fatal: Invalid scope name. Only these characters are allowed: 0-9 a-z A-Z - _ /' "$out"
 }
 
 test_scopes_using_branchname_as_scope() {
@@ -392,6 +392,21 @@ test_scopes_using_branchname_as_scope() {
 	git config git-ftp.production.password $GIT_FTP_PASSWD
 	git config git-ftp.production.url $GIT_FTP_URL
 	git checkout -b production > /dev/null 2>&1
+
+	init=$($GIT_FTP_CMD init -s)
+	rtrn=$?
+	assertEquals 0 $rtrn
+}
+
+test_scopes_using_nested_branchname() {
+	add=$($GIT_FTP_CMD add-scope nested/branch ftp://localhost/ 2>&1)
+	assertEquals 0 $?
+
+	cd $GIT_PROJECT_PATH
+	git config git-ftp.nested/branch.user $GIT_FTP_USER
+	git config git-ftp.nested/branch.password $GIT_FTP_PASSWD
+	git config git-ftp.nested/branch.url $GIT_FTP_URL
+	git checkout -b nested/branch > /dev/null 2>&1
 
 	init=$($GIT_FTP_CMD init -s)
 	rtrn=$?


### PR DESCRIPTION
Allows `/` in scopes names. This is required to enable auto detection for nested branches. (see #511) 

As well more helpful error messages are added if an invalid scope name is used.