### PR TITLE
LFTP options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Version 1.6.0-UNRELEASED
 * Pass ssh-keys to submodules if used
 * Add support for config `disable-epsv`
 * Allow `true` and `false` for boolean configurations (`insecure`, `disable-epsv`)
+* Add support for option `--insecure` for LFTP actions (download and pull)
+* Add support for FTPES for LFTP actions (download and pull)
 
 Version 1.5.2
 =============

--- a/git-ftp
+++ b/git-ftp
@@ -62,6 +62,7 @@ CURL_PUBLIC_KEY=""
 CURL_PRIVATE_KEY=""
 CURL_DISABLE_EPSV="0"
 CURL_PROXY=""
+LFTP_COMMAND_SETTINGS=""
 TMP_DIR=""
 TMP_CURL_UPLOAD_FILE=""
 TMP_CURL_DELETE_FILE=""
@@ -896,6 +897,11 @@ handle_remote_protocol_options() {
 	[ "$CURL_INSECURE" != "0" ] && REMOTE_CMD_OPTIONS+=("-k")
 }
 
+handle_lftp_settings() {
+	[ "$CURL_INSECURE" != "0" ] && LFTP_COMMAND_SETTINGS+="set ssl:verify-certificate no && "
+	LFTP_COMMAND_SETTINGS+="set ftp:list-options -a &&"
+}
+
 init_new_repository() {
 	[ -z "$URL" ] && print_error_and_die "Error: give a URL to snapshot." "$ERROR_USAGE"
 
@@ -1133,12 +1139,19 @@ download_remote_updates () {
 
 	ignore=""
 	if [ -f '.git-ftp-ignore' ]; then
-		ignore="$(grep -v '^#' .git-ftp-ignore | awk 'NF' | sed 's/^\(.*\)$/--exclude-glob "\1" /' | tr -d '\r\n')"
+		ignore="$(grep -v '^#' .git-ftp-ignore | awk 'NF' | sed 's/^\(.*\)$/--exclude-glob "\1" /' | tr -d '\r\n') "
 	fi
-	ignore+=" --exclude=^\.git/ --exclude=^\.git-ftp\.log --exclude=^\.git-ftp-ignore"
+	ignore+="--exclude=^\.git/ --exclude=^\.git-ftp\.log --exclude=^\.git-ftp-ignore"
 
-	lftp_command="set ftp:list-options -a && mirror$mirror_options $delete $ignoreall $include $ignore . $SYNCROOT && wait all && exit"
-	out="$(lftp $LFTP_OPTIONS -e "$lftp_command" -u "${REMOTE_USER},${REMOTE_PASSWD}" "${REMOTE_PROTOCOL}://${REMOTE_HOST}/${REMOTE_PATH}" 2>&1)"
+	handle_lftp_settings
+	
+	local lftp_cd=""
+	[ -n $REMOTE_PATH ] && lftp_cd="cd ${REMOTE_PATH} &&"
+	local lftp_action="mirror $mirror_options $delete $ignoreall $include $ignore . $SYNCROOT &&"
+	local lftp_exit="wait all && exit"
+	
+	lftp_command="$LFTP_COMMAND_SETTINGS $lftp_cd $lftp_action $lftp_exit"
+	out="$(lftp $LFTP_OPTIONS -e "$lftp_command" -u "${REMOTE_USER},${REMOTE_PASSWD}" "${REMOTE_PROTOCOL}://${REMOTE_HOST}/" 2>&1)"
 	print_info "$out"
 }
 

--- a/git-ftp
+++ b/git-ftp
@@ -62,6 +62,7 @@ CURL_PUBLIC_KEY=""
 CURL_PRIVATE_KEY=""
 CURL_DISABLE_EPSV="0"
 CURL_PROXY=""
+LFTP_PROTOCOL=""
 LFTP_COMMAND_SETTINGS=""
 TMP_DIR=""
 TMP_CURL_UPLOAD_FILE=""
@@ -898,6 +899,15 @@ handle_remote_protocol_options() {
 }
 
 handle_lftp_settings() {
+	LFTP_PROTOCOL="$REMOTE_PROTOCOL"
+	# Options for lftp if using FTPES
+	if [ "$REMOTE_PROTOCOL" = "ftpes" ]; then
+		LFTP_PROTOCOL="ftp"
+		LFTP_COMMAND_SETTINGS+="set ftp:ssl-force true && "
+		LFTP_COMMAND_SETTINGS+="set ftp:ssl-protect-data true && "
+		LFTP_COMMAND_SETTINGS+="set ftp:ssl-protect-list true && "
+	fi
+
 	[ "$CURL_INSECURE" != "0" ] && LFTP_COMMAND_SETTINGS+="set ssl:verify-certificate no && "
 	LFTP_COMMAND_SETTINGS+="set ftp:list-options -a &&"
 }
@@ -1151,7 +1161,7 @@ download_remote_updates () {
 	local lftp_exit="wait all && exit"
 	
 	lftp_command="$LFTP_COMMAND_SETTINGS $lftp_cd $lftp_action $lftp_exit"
-	out="$(lftp $LFTP_OPTIONS -e "$lftp_command" -u "${REMOTE_USER},${REMOTE_PASSWD}" "${REMOTE_PROTOCOL}://${REMOTE_HOST}/" 2>&1)"
+	out="$(lftp $LFTP_OPTIONS -e "$lftp_command" -u "${REMOTE_USER},${REMOTE_PASSWD}" "${LFTP_PROTOCOL}://${REMOTE_HOST}/" 2>&1)"
 	print_info "$out"
 }
 

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -890,6 +890,21 @@ test_download() {
 	assertTrue ' external file not downloaded' "[ -r 'external.txt' ]"
 }
 
+test_download_insecure() {
+	skip_without lftp
+	cd $GIT_PROJECT_PATH
+	$GIT_FTP init > /dev/null
+	echo 'foreign content' > external.txt
+	$CURL -T external.txt $CURL_URL/ 2> /dev/null
+	rtrn=$?
+	assertEquals 0 $rtrn
+	rm external.txt
+	$GIT_FTP download --insecure  > /dev/null 2>&1
+	rtrn=$?
+	assertEquals 0 $rtrn
+	assertTrue ' external file not downloaded' "[ -r 'external.txt' ]"
+}
+
 test_download_untracked() {
 	skip_without lftp
 	cd $GIT_PROJECT_PATH


### PR DESCRIPTION
Add support for `--insecure` and FTPS when using LFTP (download and pull).

I did some refactoring in `download_remote_updates()` to make it more readable and make the mechanism similar to the one used for curl. This way it’s easier to maintain.