### PR TITLE
Passwords: Error detection and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Version 1.6.0-UNRELEASED
 * Allow `true` and `false` for boolean configurations (`insecure`, `disable-epsv`)
 * Add support for option `--insecure` for LFTP actions (download and pull)
 * Add support for FTPES for LFTP actions (download and pull)
+* Add better error messages for curl errors
 
 Version 1.5.2
 =============

--- a/git-ftp
+++ b/git-ftp
@@ -1640,7 +1640,7 @@ do
 						REMOTE_PASSWD="$2"
 						shift
 					else
-						print_error_and_die "Too few arguments for option -p." "$ERROR_MISSING_ARGUMENTS"
+						print_error_and_die "Too few arguments for option -p. Maybe the manual will help: https://github.com/git-ftp/git-ftp/blob/master/man/git-ftp.1.md#passwords" "$ERROR_MISSING_ARGUMENTS"
 					fi
 					;;
 			esac

--- a/git-ftp
+++ b/git-ftp
@@ -298,10 +298,54 @@ get_keychain_password () {
 }
 
 # Checks if last command was successful
+#
+# $1 - error message
+# $2 - error code to produce
+#
 check_exit_status() {
-	if [ $? -ne 0 ]; then
-		print_error_and_die "$1, exiting..." "$2"
+	check_exit_status_not_equals $? 0 "$1" "$2"
+}
+
+# Checks if exit status equals a given value. If false sends exit command.
+#
+# $1 - status code to check
+# $2 - code to test against
+# $3 - error message
+# $4 - error code to produce
+#
+check_exit_status_equals() {
+	if [ $1 -eq $2 ]; then
+		print_error_and_die "$3, exiting..." "$4"
 	fi
+}
+
+# Checks if exit status not equals a given value
+#
+# $1 - status code to check
+# $2 - code to test against
+# $3 - error message
+# $4 - error code to produce
+#
+check_exit_status_not_equals() {
+	if [ $1 -ne $2 ]; then
+		print_error_and_die "$3, exiting..." "$4"
+	fi
+}
+
+# Checks if a given curl exit code was successful and if not exits with a nice error message (in some cases)
+#
+# $1 - exit code to check
+# $2 - message: a custom message that is put in front of the error message
+# $3 - error code: code to exit with if $1 is bad
+#
+check_curl_exit_status() {
+	case $1 in
+		0) ;;
+		9) print_error_and_die "$2 Access to resource denied. This usually means that the file or directory does not exist. Wrong path? exiting..." "$3" ;;
+		67) print_error_and_die "$2 Can't access remote '$REMOTE_BASE_URL_DISPLAY'. Failed to log in. Correct user and password? exiting..." "$3" ;;
+		78) print_error_and_die "$2 The resource does not exist. exiting..." "$3" ;;
+		*) print_error_and_die "$2 Can't access remote '$REMOTE_BASE_URL_DISPLAY'. Network down? Wrong URL? exiting..." "$3" ;;
+	esac
 }
 
 get_config() {

--- a/git-ftp
+++ b/git-ftp
@@ -668,7 +668,7 @@ set_deployed_sha1_failable() {
 
 set_deployed_sha1() {
 	set_deployed_sha1_failable
-	check_exit_status "Could not get last commit. Network down? Wrong URL? Use 'git ftp init' for the initial push." "$ERROR_DOWNLOAD"
+	check_curl_exit_status $? "Could not get last commit. Use 'git ftp init' for the initial push." "$ERROR_DOWNLOAD"
 	write_log "Last deployed SHA1 for $REMOTE_HOST/$REMOTE_PATH is $DEPLOYED_SHA1."
 }
 
@@ -1438,9 +1438,8 @@ check_remote_access() {
 		curl "${CURL_ARGS[@]}" -Q "MKDIR $REMOTE_PATH" > /dev/null
 		EXIT_CODE=$?
 	fi
-	if [ $EXIT_CODE -ne 0 ]; then
-		print_error_and_die "Can't access remote '$REMOTE_BASE_URL_DISPLAY', exiting..." "$ERROR_UPLOAD"
-	fi
+
+	check_curl_exit_status "$EXIT_CODE" "" "$ERROR_UPLOAD"
 }
 
 check_deployed_sha1() {

--- a/git-ftp
+++ b/git-ftp
@@ -469,7 +469,6 @@ upload_file() {
 	CURL_ARGS+=(--ftp-create-dirs)
 	CURL_ARGS+=("$REMOTE_BASE_URL/${REMOTE_PATH}${DEST_FILE}")
 	curl "${CURL_ARGS[@]}"
-	check_exit_status "Could not upload file: '${REMOTE_PATH}$DEST_FILE'." "$ERROR_UPLOAD"
 }
 
 upload_file_buffered() {
@@ -544,7 +543,7 @@ upload_local_sha1() {
 	write_log "Uploading commit log to $REMOTE_BASE_URL_DISPLAY/${REMOTE_PATH}$DEPLOYED_SHA1_FILE."
 	if [ $DRY_RUN -ne 1 ]; then
 		echo "$LOCAL_SHA1" | upload_file - "$DEPLOYED_SHA1_FILE"
-		check_exit_status "Could not upload." "$ERROR_UPLOAD"
+		check_curl_exit_status $? "Could not upload." "$ERROR_UPLOAD"
 	fi
 	print_info "Last deployment changed from $DEPLOYED_SHA1 to $LOCAL_SHA1.";
 	PREV_DEPLOYED_SHA1="$DEPLOYED_SHA1"

--- a/git-ftp
+++ b/git-ftp
@@ -282,11 +282,14 @@ get_keychain_password () {
 		fi
 
 		[ -z "$KEYCHAIN_USER" ] && print_error_and_die "Missing keychain account." "$ERROR_MISSING_ARGUMENTS"
-		CURL_ARGS=(-a "$KEYCHAIN_USER")
-		[ -n "$KEYCHAIN_HOST" ] && CURL_ARGS+=(-s "$KEYCHAIN_HOST")
+		
+		local KEYCHAIN_ARGS=(-a "$KEYCHAIN_USER")
+		[ -n "$KEYCHAIN_HOST" ] && KEYCHAIN_ARGS+=(-s "$KEYCHAIN_HOST")
+
+		write_log "Read password from keychain."
 
 		local pass
-		if pass="$(security find-internet-password "${CURL_ARGS[@]}" -g 2>&1 > /dev/null)"; then
+		if pass="$(security find-internet-password "${KEYCHAIN_ARGS[@]}" -g 2>&1 > /dev/null)"; then
 			without_prefix="${pass#password: \"}"
 			REMOTE_PASSWD="${without_prefix%\"}"
 		else

--- a/man/git-ftp.1.md
+++ b/man/git-ftp.1.md
@@ -87,7 +87,7 @@ different and handles only those files. That saves time and bandwidth.
 :	FTP login name. If no argument is given, local user will be taken.
 
 `-p [password]`, `--passwd [password]`
-:	FTP password. See `-P` for interactive password prompt.
+:	FTP password. See `-P` for interactive password prompt. ([note](#passwords))
 
 `-P`, `--ask-passwd`
 :	Ask for FTP password interactively.
@@ -300,6 +300,8 @@ Everyone likes examples:
 After setting those defaults, push to *john@ftp.example.com* is as simple as
 
 	$ git ftp push
+
+If you run into issues with setting up your password please check this [note](#passwords).
 
 # SCOPES
 
@@ -559,7 +561,19 @@ hook. This hook is **not** bypassed by the --no-verify option.
 It is meant primarily for notification and its exit status does not have any
 effect.
 
-# NETRC
+# PASSWORDS
+
+If your password contains special characters you have to take it with care. In most cases it is a good idea to quote passwords with single quotes:
+
+	--passwd '#my$fancy!secret'
+
+Mostly `--ask-passwd` works even if `--passwd` does not work. So maybe you can give this a try.
+
+Quoting also works if setting the [default](#defaults) with `git config`:
+
+	$ git config git-ftp.password '#my$fancy!secret'
+
+## NETRC
 
 In the backend, Git-ftp uses curl.
 This means `~/.netrc` could be used beside the other options of Git-ftp

--- a/man/git-ftp.1.md
+++ b/man/git-ftp.1.md
@@ -92,8 +92,8 @@ different and handles only those files. That saves time and bandwidth.
 `-P`, `--ask-passwd`
 :	Ask for FTP password interactively.
 
-`-k [[user]@[account]]`, `--keychain [[user]@[account]]`
-:	FTP password from KeyChain (Mac OS X only).
+`-k [[account]@[host]]`, `--keychain [[account]@[host]]`
+:	FTP password from KeyChain (macOS only).
 
 `-a`, `--all`
 :	Uploads all files of current Git checkout.
@@ -590,6 +590,43 @@ For example, if you set up your .netrc file like this you can just call
 	git ftp init ftp.example.com
 
 Of course this can be combined with the [defaults feature](#defaults) to set config defaults for other options as well.
+
+## Keychain on macOS
+
+On macOS you can use the built in keychain to store and get your passwords.
+
+You can use this feature by using the option `--keychain` in your command:
+
+	$ git ftp init --keychain account@host ftpes://host
+
+You can omit the value for this option. Then git-ftp will guess the account and hostname from user and url.
+
+Or you can set a config for this, so you don’t need to repeat yourself (see [defaults](#defaults) for details):
+
+	$ git config git-ftp.keychain account@host
+
+You can omit the hostname here. If there is no `@` in the config value git-ftp will guess the hostname from url.
+
+If you run a command using the keychain feature, the system might ask you if git-ftp is allowed to access the keychain entry.
+If the keychain is locked you have to enter the keychain password (not the value of the entry), sometimes twice.
+
+If your password is not in your keychain yet it is recommended adding it using the following command:
+
+	$ security add-internet-password -a account -r "ftp " -s host -w secr3t
+
+The options are:
+- `-a`: user account
+- `-r`: protocol; has to be exactly 4 characters long, so if you use `FTP` it should be `"ftp "`, for `FTPS` and `FTPES` use `ftps`
+  and for SSH with password auth you can use `"ftp "` as well.
+- `-s`: your host name; includes subdomains but no paths
+- `-w`: password
+
+You can omit the option `-r` and everything will work fine, but the _Keychain Access_ Utility will not show the server in the field “Where:”.
+This is only shown if `-r` and `-s` are set both. \
+If you create a keychain entry with the _Keychain Access_ Utility it creates a generic password and not an internet password.
+Therefore, unfortunately, this will not work.
+
+Please not that the keychain entry can not be used for password protected private keys in SSH.
 
 # EXIT CODES
 

--- a/man/git-ftp.1.md
+++ b/man/git-ftp.1.md
@@ -569,7 +569,11 @@ If your password contains special characters you have to take it with care. In m
 
 Mostly `--ask-passwd` works even if `--passwd` does not work. So maybe you can give this a try.
 
-Quoting also works if setting the [default](#defaults) with `git config`:
+If your password starts with a hyphen/dash (`-`) even quoting might fail.
+This is [by design](https://github.com/git-ftp/git-ftp/issues/468) and will not be fixed.
+In this case you can use one of the other options to set your password: the defaults feature using `git config`, `--ask-passwd` or `~/.netrc`.
+
+Quoting also works if a [default](#defaults) is set with `git config`:
 
 	$ git config git-ftp.password '#my$fancy!secret'
 

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -343,6 +343,17 @@ test_push_unknown_commit_say_yes() {
 	assertTrue ' test 1.txt uploaded' "remote_file_equals 'test 1.txt'"
 }
 
+test_catchup_invalid_credentials() {
+	REMOTE_BASE_URL_DISPLAY="ftp://$GIT_FTP_USER:***@$GIT_FTP_HOST$GIT_FTP_PORT"
+	cd $GIT_PROJECT_PATH
+	$GIT_FTP init -n
+	push=$($GIT_FTP push)
+	init="$($GIT_FTP_CMD catchup -u $GIT_FTP_USER -p wrongPassword $GIT_FTP_URL 2>&1)"
+	rtrn=$?
+	assertEquals "fatal: Could not upload. Can't access remote '$REMOTE_BASE_URL_DISPLAY'. Failed to log in. Correct user and password? exiting..." "$init"
+	assertEquals 4 $rtrn
+}
+
 test_defaults() {
 	cd $GIT_PROJECT_PATH
 	git config git-ftp.user $GIT_FTP_USER

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -151,6 +151,22 @@ test_init_fails() {
 	#assertEquals 1 $error_count
 }
 
+test_init_invalid_password() {
+	REMOTE_BASE_URL_DISPLAY="ftp://$GIT_FTP_USER:***@$GIT_FTP_HOST$GIT_FTP_PORT"
+	init="$($GIT_FTP_CMD init -u $GIT_FTP_USER -p wrongPassword $GIT_FTP_URL 2>&1)"
+	rtrn=$?
+	assertEquals "fatal:  Can't access remote '$REMOTE_BASE_URL_DISPLAY'. Failed to log in. Correct user and password? exiting..." "$init"
+	assertEquals 4 $rtrn
+}
+
+test_init_invalid_user() {
+	REMOTE_BASE_URL_DISPLAY="ftp://invalidUser:***@$GIT_FTP_HOST$GIT_FTP_PORT"
+	init="$($GIT_FTP_CMD init -u invalidUser -p $GIT_FTP_PASSWD $GIT_FTP_URL 2>&1)"
+	rtrn=$?
+	assertEquals "fatal:  Can't access remote '$REMOTE_BASE_URL_DISPLAY'. Failed to log in. Correct user and password? exiting..." "$init"
+	assertEquals 4 $rtrn
+}
+
 test_inits_and_pushes() {
 	cd $GIT_PROJECT_PATH
 
@@ -197,7 +213,26 @@ test_pushes_and_fails() {
 	cd $GIT_PROJECT_PATH
 	push="$($GIT_FTP push 2>&1)"
 	rtrn=$?
-	assertEquals "fatal: Could not get last commit. Network down? Wrong URL? Use 'git ftp init' for the initial push., exiting..." "$push"
+	assertEquals "fatal: Could not get last commit. Use 'git ftp init' for the initial push. Access to resource denied. This usually means that the file or directory does not exist. Wrong path? exiting..." "$push"
+	assertEquals 5 $rtrn
+}
+
+test_push_invalid_password() {
+	REMOTE_BASE_URL_DISPLAY="ftp://$GIT_FTP_USER:***@$GIT_FTP_HOST$GIT_FTP_PORT"
+	$GIT_FTP init -n
+	push=$($GIT_FTP push)
+	init="$($GIT_FTP_CMD push -u $GIT_FTP_USER -p wrongPassword $GIT_FTP_URL 2>&1)"
+	rtrn=$?
+	assertEquals "fatal: Could not get last commit. Use 'git ftp init' for the initial push. Can't access remote '$REMOTE_BASE_URL_DISPLAY'. Failed to log in. Correct user and password? exiting..." "$init"
+	assertEquals 5 $rtrn
+}
+
+test_push_invalid_user() {
+	REMOTE_BASE_URL_DISPLAY="ftp://invalidUser:***@$GIT_FTP_HOST$GIT_FTP_PORT"
+	$GIT_FTP init -n
+	init="$($GIT_FTP_CMD push -u invalidUser -p $GIT_FTP_PASSWD $GIT_FTP_URL 2>&1)"
+	rtrn=$?
+	assertEquals "fatal: Could not get last commit. Use 'git ftp init' for the initial push. Can't access remote '$REMOTE_BASE_URL_DISPLAY'. Failed to log in. Correct user and password? exiting..." "$init"
 	assertEquals 5 $rtrn
 }
 


### PR DESCRIPTION
This introduces a mechanism to check curl commands for exit code `67` to catch authentication problems and displaying a proper error message in such cases.

In addition some test are adjusted and added to cover the new behaviour.

And then some documentation for password specific issues is added, in particular for passwords with special characters and the OSX keychain.