### PR TITLE
Pull no commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ Version 1.6.0-UNRELEASED
 * Fix/Add suport for nested branch names by allowing `/` in scope names
 * Pass insecure-flag to submodules
 * Pass ssh-keys to submodules if used
-* Add support for config `disable-epsv`
-* Allow `true` and `false` for boolean configurations (`insecure`, `disable-epsv`)
+* Add support for config `disable-epsv` and `no-commit`
+* Allow `true` and `false` for boolean configurations (`insecure`, `disable-epsv`, `no-commit`)
 * Add support for option `--insecure` for LFTP actions (download and pull)
 * Add support for FTPES for LFTP actions (download and pull)
 * Add better error messages for curl errors

--- a/git-ftp
+++ b/git-ftp
@@ -83,6 +83,7 @@ declare -i ENABLE_POST_HOOK_ERRORS=0
 declare -i AUTO_INIT=0
 declare -i INSECURE=0
 declare -i CURL_DISABLE_EPSV=0
+declare -i NO_COMMIT=0
 
 # ------------------------------------------------------------
 # Constant Exit Error Codes
@@ -1167,6 +1168,15 @@ set_curl_proxy() {
 	[ -z "$CURL_PROXY" ] && CURL_PROXY="$(git config --get http.proxy)"
 }
 
+set_merge_args() {
+	local config="$(get_config no-commit)"
+	[ -n "$config" ] && NO_COMMIT=1
+	
+	if [ $NO_COMMIT -eq 1 ]; then
+		MERGE_ARGS="$MERGE_ARGS --no-commit --no-ff"
+	fi
+}
+
 get_protocol_of_url() {
 	echo "$1" | tr '[:upper:]' '[:lower:]' | egrep '^(ftp|sftp|ftps|ftpes)://' | cut -d ':' -f 1
 }
@@ -1387,6 +1397,7 @@ action_pull() {
 	check_curl_access
 	set_deployed_sha1
 	handle_fetch
+	set_merge_args
 	git merge $MERGE_ARGS $LOCAL_SHA1
 }
 
@@ -1768,8 +1779,8 @@ do
 			write_log "Using active mode."
 			;;
 		--no-commit)
-			MERGE_ARGS="$MERGE_ARGS --no-commit"
-			write_log "Adding --no-commit to merge arguments: $MERGE_ARGS"
+			NO_COMMIT=1
+			write_log "Adding --no-commit to merge arguments"
 			;;
 		--changed-only)
 			DOWNLOAD_CHANGED_ONLY=1

--- a/git-ftp
+++ b/git-ftp
@@ -57,10 +57,8 @@ LOCAL_SHA1=""
 SYNCROOT=""
 SNAPSHOT_DIR=""
 CURL_PROTOCOL=""
-CURL_INSECURE="0"
 CURL_PUBLIC_KEY=""
 CURL_PRIVATE_KEY=""
-CURL_DISABLE_EPSV="0"
 CURL_PROXY=""
 LFTP_PROTOCOL=""
 LFTP_COMMAND_SETTINGS=""
@@ -71,6 +69,7 @@ TMP_GITFTP_UPLOAD=""
 TMP_GITFTP_DELETE=""
 TMP_GITFTP_INCLUDE=""
 declare -a CURL_ARGS
+declare -a GIT_SUBMODULES
 declare -i VERBOSE=0
 declare -i IGNORE_DEPLOYED=0
 declare -i DOWNLOAD_CHANGED_ONLY=0
@@ -81,8 +80,9 @@ declare -i ACTIVE_MODE=0
 declare -i USE_KEYCHAIN=0
 declare -i EXECUTE_HOOKS=1
 declare -i ENABLE_POST_HOOK_ERRORS=0
-declare -a GIT_SUBMODULES
 declare -i AUTO_INIT=0
+declare -i INSECURE=0
+declare -i CURL_DISABLE_EPSV=0
 
 # ------------------------------------------------------------
 # Constant Exit Error Codes
@@ -454,7 +454,7 @@ set_default_curl_options() {
 	if [ $ACTIVE_MODE -eq 1 ]; then
 		CURL_ARGS+=(-P "-")
 	else
-		if [ "$CURL_DISABLE_EPSV" != "0" ]; then
+		if [ $CURL_DISABLE_EPSV -eq 1 ]; then
 			CURL_ARGS+=(--disable-epsv)
 		fi
 	fi
@@ -891,12 +891,12 @@ set_submodule_args() {
 	if [ $ACTIVE_MODE -eq 1 ]; then
 		args+=(--active)
 	else
-		if [ "$CURL_DISABLE_EPSV" != "0" ]; then
+		if [ $CURL_DISABLE_EPSV -eq 1 ]; then
 			args+=(--disable-epsv)
 		fi
 	fi
 
-	[ $CURL_INSECURE -eq 1 ] && args+=(--insecure)
+	[ $INSECURE -eq 1 ] && args+=(--insecure)
 	[ $IGNORE_DEPLOYED -eq 1 ] && args+=(--all)
 
 	if [ $VERBOSE -eq 1 ]; then
@@ -941,7 +941,7 @@ handle_remote_protocol_options() {
 	fi
 
 	# Require users' explicit consent for insecure connections
-	[ "$CURL_INSECURE" != "0" ] && REMOTE_CMD_OPTIONS+=("-k")
+	[ $INSECURE -eq 1 ] && REMOTE_CMD_OPTIONS+=("-k")
 }
 
 handle_lftp_settings() {
@@ -954,7 +954,7 @@ handle_lftp_settings() {
 		LFTP_COMMAND_SETTINGS+="set ftp:ssl-protect-list true && "
 	fi
 
-	[ "$CURL_INSECURE" != "0" ] && LFTP_COMMAND_SETTINGS+="set ssl:verify-certificate no && "
+	[ $INSECURE -eq 1 ] && LFTP_COMMAND_SETTINGS+="set ssl:verify-certificate no && "
 	LFTP_COMMAND_SETTINGS+="set ftp:list-options -a &&"
 }
 
@@ -1114,11 +1114,11 @@ set_remotes() {
 	set_remote_cacert
 	write_log "CACert is '$REMOTE_CACERT'."
 
-	set_curl_insecure
-	write_log "Insecure is '$CURL_INSECURE'."
+	set_insecure
+	write_log "Insecure is '$INSECURE'."
 	
 	set_curl_disable_epsv
-	[ "$CURL_DISABLE_EPSV" != "0" ] && write_log "Disable EPSV is '$CURL_DISABLE_EPSV'."
+	[ $CURL_DISABLE_EPSV -eq 1 ] && write_log "Disable EPSV is '$CURL_DISABLE_EPSV'."
 
 	set_curl_proxy
 	write_log "Proxy is '$CURL_PROXY'."
@@ -1152,9 +1152,9 @@ urlencode() {
 	echo "${encoded}"
 }
 
-set_curl_insecure() {
+set_insecure() {
 	local config="$(get_config insecure)"
-	[ -n "$config" ] && CURL_INSECURE="$(boolean $config)"
+	[ -n "$config" ] && INSECURE="$(boolean $config)"
 }
 
 set_curl_disable_epsv() {
@@ -1706,7 +1706,7 @@ do
 			exit 0
 			;;
 		--insecure)
-			CURL_INSECURE=1
+			INSECURE=1
 			write_log "Insecure SSL/TLS connection allowed"
 			;;
 		--cacert*)

--- a/man/git-ftp.1.md
+++ b/man/git-ftp.1.md
@@ -56,6 +56,7 @@ different and handles only those files. That saves time and bandwidth.
 `pull` (EXPERIMENTAL)
 :	Downloads changes from the remote host into a separate commit
 	and merges that into your current branch.
+	If you just want to download the files without a merge, consider `download`.
 	This feature needs lftp to be installed.
 
 `snapshot` (EXPERIMENTAL)
@@ -164,6 +165,9 @@ different and handles only those files. That saves time and bandwidth.
 
 `--no-commit`
 :	Stop while merging downloaded changes during the pull action.
+	A commit is made anyway, but the merge is interrupted.
+	If you just want to download the files you could also consider the action
+	`download`.
 
 `--changed-only`
 :	During the ftp mirror operation during a pull command, consider only
@@ -296,6 +300,7 @@ Everyone likes examples:
 	$ git config git-ftp.keychain user@example.com
 	$ git config git-ftp.remote-root htdocs
 	$ git config git-ftp.disable-epsv 1
+	$ git config git-ftp.no-commit 1
 
 After setting those defaults, push to *john@ftp.example.com* is as simple as
 

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -1017,6 +1017,40 @@ test_pull_no_commit() {
 	assertEquals $LOCAL_SHA1 $(git log -n 1 --pretty=format:%H)
 }
 
+test_pull_no_commit_config() {
+	git config git-ftp.no-commit true
+	skip_without lftp
+	$GIT_FTP init > /dev/null
+	echo 'foreign content' > external.txt
+	$CURL -T external.txt $CURL_URL/ 2> /dev/null
+	rm external.txt
+	echo 'own content' > internal.txt
+	git add . > /dev/null 2>&1
+	git commit -a -m "local modification" > /dev/null 2>&1
+	LOCAL_SHA1=$(git log -n 1 --pretty=format:%H)
+	$GIT_FTP pull > /dev/null 2>&1
+	rtrn=$?
+	assertEquals 0 $rtrn
+	assertTrue ' external file not downloaded' "[ -r 'external.txt' ]"
+	assertEquals $LOCAL_SHA1 $(git log -n 1 --pretty=format:%H)
+}
+
+test_pull_no_commit_external_only() {
+	skip_without lftp
+	$GIT_FTP init > /dev/null
+	echo 'foreign content' > external.txt
+	$CURL -T external.txt $CURL_URL/ 2> /dev/null
+	rm external.txt
+	LOCAL_SHA1=$(git log -n 1 --pretty=format:%H)
+	out="$($GIT_FTP pull --no-commit 2>&1)"
+	rtrn=$?
+	assertEquals 0 $rtrn
+	assertTrue ' external file not downloaded' "[ -r 'external.txt' ]"
+	assertEquals $LOCAL_SHA1 $(git log -n 1 --pretty=format:%H)
+	echo "$out" | grep --quiet "Fast-forward"
+	assertEquals "Fast-forward commit was performed." 1 $?
+}
+
 test_pull_dry_run() {
 	skip_without lftp
 	$GIT_FTP init > /dev/null

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -1231,10 +1231,24 @@ test_insecure_from_config() {
 	assertEquals 0 $?
 }
 
+test_insecure_from_config_false() {
+	git config git-ftp.insecure 0
+	out="$($GIT_FTP init -v 2>/dev/null)"
+	echo "$out" | grep --quiet "Insecure is '0'"
+	assertEquals 0 $?
+}
+
 test_insecure_from_config_boolean() {
 	git config git-ftp.insecure true
 	out="$($GIT_FTP init -v 2>/dev/null)"
 	echo "$out" | grep --quiet "Insecure is '1'"
+	assertEquals 0 $?
+}
+
+test_insecure_from_config_boolean_false() {
+	git config git-ftp.insecure false
+	out="$($GIT_FTP init -v 2>/dev/null)"
+	echo "$out" | grep --quiet "Insecure is '0'"
 	assertEquals 0 $?
 }
 
@@ -1276,11 +1290,25 @@ test_epsv_from_config() {
 	assertEquals 0 $?
 }
 
+test_epsv_from_config_false() {
+	git config git-ftp.disable-epsv 0
+	out="$($GIT_FTP init -v 2>/dev/null)"
+	echo "$out" | grep --quiet "Disable EPSV is '1'."
+	assertEquals 1 $?
+}
+
 test_epsv_from_config_boolean() {
 	git config git-ftp.disable-epsv true
 	out="$($GIT_FTP init -v 2>/dev/null)"
 	echo "$out" | grep --quiet "Disable EPSV is '1'."
 	assertEquals 0 $?
+}
+
+test_epsv_from_config_boolean_false() {
+	git config git-ftp.disable-epsv false
+	out="$($GIT_FTP init -v 2>/dev/null)"
+	echo "$out" | grep --quiet "Disable EPSV is '1'."
+	assertEquals 1 $?
 }
 
 test_epsv_options() {


### PR DESCRIPTION
- Changes processing of boolean configs by handling them as integers instead of strings.
- Forces non-fast-forward merges if `--no-commit` is set for pull action (see #528)
- Adds default processing for `no-commit`
- Adds some detail to documentation