### PR TITLE
Add config for stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,67 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 84
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 28
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels:
+  - needs_info
+  - question
+  - ci
+  - duplicate
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - bug
+  - enhancement
+  - documentation
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: true
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. 
+  If you have found a solution for this, it would be great if you could share
+  it here to help others. Thank you for your question.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+ closeComment: >
+   This issue will get closed for now but please feel free to re-open it if 
+   you still have this problem with Git-ftp.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 10
+
+# Limit to only `issues` or `pulls`
+only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# pulls:
+#   daysUntilStale: 30
+#   markComment: >
+#     This pull request has been automatically marked as stale because it has not had
+#     recent activity. It will be closed if no further activity occurs. Thank you
+#     for your contributions.
+
+# issues:
+#   exemptLabels:
+#     - confirmed


### PR DESCRIPTION
Add config file for https://github.com/probot/stale to handle some inactive issues automatically.

- mark as stale after 84 days (12 weeks)
- close after another 28 days (4 weeks)

**But**

- only if one of the following labels is set: needs_info, question, ci, duplicate. Only issues that we have explicitly marked are considered for closing.
- and additionally ignore the issue if one of these labels is set: bug, enhancement, documentation. So an issue marked as "duplicate, enhancement" will not be closed automatically.
- and if an assignee is set, ignore it as well. So things where someone already said "I'll take care of it" won't be closed either.

**And**

- Before marking as stale post a nice comment with explanation.
- Before closing post a nice comment to embolden the poster to reopen the issue if he still has this problem.

Translated with www.DeepL.com/Translator