### PR TITLE
Fix stale-bot onlyLabels

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,17 +8,21 @@ daysUntilStale: 84
 daysUntilClose: 28
 
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
-onlyLabels:
-  - needs_info
-  - question
-  - ci
-  - duplicate
+onlyLabels: []
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
   - bug
   - enhancement
   - documentation
+  - pending
+  - discussion
+  - confirmed
+  - in_progress
+  - Windows
+  - ci
+  - SFTP
+  - wontfix
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false


### PR DESCRIPTION
I misunderstood the config for stale-bot sorry.

I thought of the onlyLabels as "one of these labels" has to be set, but in fact it is "ALL of these labels has to be set". And obviously we don’t have a single issue that has all these four labels (needs_info, question, ci, duplicate). So the bot might work but is not finding any issue to close.

So we had to change the label strategy for the bot and came up with this solution.