### PR TITLE
Adding link to git-ftp github action

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ Dan Rench <github.com/drench>
 Marc Addeo <marcaddeo@gmail.com>
 Hugo Laloge <hugo.laloge@yahoo.fr>
 Piran Montford <github.com/piranm>
+Sam Kirkland <github.com/SamKirkland>

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Further Reading
 * Check [git-ftp issues on GitHub] for open issues.
 * Follow this project on twitter [@gitftp].
 
-* Deploy with [Git-ftp and Bitbucket Pipelines](https://www.youtube.com/watch?v=8HZhHtZebdw) (video tutorial).
+* Deploy with [git-ftp and GitHub Actions](https://github.com/marketplace/actions/ftp-deploy)
+* Deploy with [git-ftp and Bitbucket Pipelines](https://www.youtube.com/watch?v=8HZhHtZebdw) (video tutorial).
 
 Limitations
 -----------


### PR DESCRIPTION
I wrote [this github action](https://github.com/SamKirkland/FTP-Deploy-Action) that allows you to automatically deploy code via github actions. This is just a wrapper around git-ftp 😄 