### PR TITLE
Add flag --pass for passphrase with private key

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -444,7 +444,15 @@ set_default_curl_options() {
 	IFS=" "
 	CURL_ARGS=("${REMOTE_CMD_OPTIONS[@]}")
 	IFS="$OIFS"
-	CURL_ARGS+=(--globoff)
+	
+    CURL_ARGS+=(--globoff)
+
+    # Change by Rafael Silva rafae.silva@alfasoft.pt
+    PASSPHRASE=$(get_config passphrase)
+    if [ ! -z "$PASSPHRASE" ]; then
+        CURL_ARGS+=(--pass $(get_config passphrase))
+    fi
+
 	if [ -n "$CURL_PROXY" ]; then
 		CURL_ARGS+=(--proxy "$CURL_PROXY")
 	fi


### PR DESCRIPTION
Adding git config option `git-ftp.passphrase` to use private key with SFTP.