### PR TITLE
Replace grep in `filter_ignore_files()` with `git ls-files --ignored`

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -789,7 +789,7 @@ add_include_file() {
 filter_ignore_files() {
 	[ -f '.git-ftp-ignore' ] || return
 	local patterns="$TMP_DIR/ignore_tmp"
-	grep -v '^#.*$\|^\s*$' '.git-ftp-ignore' | tr -d '\r' > "$patterns"
+	git ls-files --ignored --cached --exclude-from='.git-ftp-ignore' | tr -d '\r' > "$patterns"
 	filter_file "$patterns" "$1"
 	filter_file "$patterns" "$2"
 	rm -f "$patterns"


### PR DESCRIPTION
This is a follow up of https://github.com/git-ftp/git-ftp/issues/591