### PR TITLE
Fix issue with Curl and space characters in filename

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -478,7 +478,8 @@ upload_file() {
 upload_file_buffered() {
 	local SRC_FILE="$1"
 	local DEST_FILE="${SRC_FILE#$SYNCROOT}"
-	local ENC_DEST_FILE="$(echo "${DEST_FILE//#/%23}" | sed 's/ /%20/g')"
+	local ENC_DEST_FILE="${DEST_FILE//#/%23}"
+	local ENC_DEST_FILE="${ENC_DEST_FILE// /%20}"
 	echo "-T \"./$SRC_FILE\"
 url = \"$REMOTE_BASE_URL/${REMOTE_PATH}${ENC_DEST_FILE}\"" >> "$TMP_CURL_UPLOAD_FILE"
 }

--- a/git-ftp
+++ b/git-ftp
@@ -478,7 +478,7 @@ upload_file() {
 upload_file_buffered() {
 	local SRC_FILE="$1"
 	local DEST_FILE="${SRC_FILE#$SYNCROOT}"
-	local ENC_DEST_FILE="${DEST_FILE//#/%23}"
+	local ENC_DEST_FILE="$(echo "${DEST_FILE//#/%23}" | sed 's/ /%20/g')"
 	echo "-T \"./$SRC_FILE\"
 url = \"$REMOTE_BASE_URL/${REMOTE_PATH}${ENC_DEST_FILE}\"" >> "$TMP_CURL_UPLOAD_FILE"
 }

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -873,6 +873,19 @@ test_file_with_dash() {
 	assertFalse "file $dir/$file still exists in $CURL_URL" "remote_file_exists '$dir/$file'"
 }
 
+# issue #633
+test_file_with_spaces() {
+	init=$($GIT_FTP init)
+	# add a file
+	file='file with spaces in filename.txt'
+	echo "1" > "./$file"
+	git add "$file"
+	git commit -m "change" > /dev/null 2>&1
+	push=$($GIT_FTP push)
+	rtrn=$?
+	assertEquals 0 $rtrn
+}
+
 test_syncroot() {
 	syncroot='foo bar'
 	mkdir "$syncroot" && echo "test" > "$syncroot/syncroot.txt"


### PR DESCRIPTION
Fixes #633 

Fixes an issue with recent versions of Curl not handling correctly space characters in URLs
Curl now seems to not accept URLs with spaces : https://github.com/curl/curl/issues/8654

To fix this issue, space characters are replaced by %20