### PR TITLE
Adding --no-post-hooks to bypass post hooks.

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -79,6 +79,7 @@ declare -i ENABLE_REMOTE_LCK=0
 declare -i ACTIVE_MODE=0
 declare -i USE_KEYCHAIN=0
 declare -i EXECUTE_HOOKS=1
+declare -i EXECUTE_POST_HOOKS=1
 declare -i ENABLE_POST_HOOK_ERRORS=0
 declare -i AUTO_INIT=0
 declare -i INSECURE=0
@@ -577,7 +578,7 @@ post_push_hook() {
 	fi
 	local hook="$hooks_dir/post-ftp-push"
 
-	if [ -e "$hook" ]; then
+	if [ "$EXECUTE_POST_HOOKS" -eq 1 -a -e "$hook" ]; then
 		local scope="${SCOPE:-$REMOTE_HOST}"
 		local url="$REMOTE_BASE_URL_DISPLAY/$REMOTE_PATH"
 		write_log "Trigger post-ftp-push hook with: $scope, $url, $LOCAL_SHA1, $PREV_DEPLOYED_SHA1"
@@ -1799,6 +1800,10 @@ do
 			;;
 		--no-verify)
 			EXECUTE_HOOKS=0
+			shift
+			;;
+		--no-post-hooks)
+			EXECUTE_POST_HOOKS=0
 			shift
 			;;
 		--enable-post-errors)

--- a/git-ftp
+++ b/git-ftp
@@ -78,7 +78,7 @@ declare -i FORCE=0
 declare -i ENABLE_REMOTE_LCK=0
 declare -i ACTIVE_MODE=0
 declare -i USE_KEYCHAIN=0
-declare -i EXECUTE_HOOKS=1
+declare -i EXECUTE_PRE_HOOKS=1
 declare -i EXECUTE_POST_HOOKS=1
 declare -i ENABLE_POST_HOOK_ERRORS=0
 declare -i AUTO_INIT=0
@@ -197,6 +197,7 @@ OPTIONS
 	--no-commit		Perform the merge at the and of pull but do not autocommit, to have the chance to inspect and further tweak the merge result before committing.
 	--changed-only		Download or pull only files changed since the deployed commit while ignoring all other files.
 	--no-verify		Bypass the pre-ftp-push hook.
+	--no-post-hooks		Bypass the post-ftp-push hook.
 	--enable-post-errors	Fails if post-ftp-push hook raises an error
 	--disable-epsv		Tell curl to disable the use of the EPSV command when doing passive FTP transfers. Curl will normally always first attempt to use EPSV before PASV, but with this option, it will not try using EPSV.
 	--auto-init		Automatically run init action when running push action
@@ -563,7 +564,7 @@ pre_push_hook() {
 	fi
 	local hook="$hooks_dir/pre-ftp-push"
 
-	if [ "$EXECUTE_HOOKS" -eq 1 -a -e "$hook" ]; then
+	if [ "$EXECUTE_PRE_HOOKS" -eq 1 -a -e "$hook" ]; then
 		local scope="${SCOPE:-$REMOTE_HOST}"
 		local url="$REMOTE_BASE_URL_DISPLAY/$REMOTE_PATH"
 		write_log "Trigger pre-ftp-push hook with: $scope, $url, $LOCAL_SHA1, $DEPLOYED_SHA1"
@@ -1799,7 +1800,7 @@ do
 			shift
 			;;
 		--no-verify)
-			EXECUTE_HOOKS=0
+			EXECUTE_PRE_HOOKS=0
 			shift
 			;;
 		--no-post-hooks)

--- a/man/git-ftp.1.md
+++ b/man/git-ftp.1.md
@@ -176,6 +176,9 @@ different and handles only those files. That saves time and bandwidth.
 `--no-verify`
 :	Bypass the pre-ftp-push hook. See **HOOKS** section.
 
+`--no-post-hooks`
+:	Bypass the post-ftp-push hook. See **HOOKS** section.
+
 `--enable-post-errors`
 :	Fails if post-ftp-push raises an error.
 
@@ -562,9 +565,9 @@ exit 0
 
 `post-ftp-push` is called after the transfer has been finished. The standard
 input is empty, but the parameters are the same as given to the `pre-ftp-push`
-hook. This hook is **not** bypassed by the --no-verify option.
-It is meant primarily for notification and its exit status does not have any
-effect.
+hook. This hook is **not** bypassed by the --no-verify option, but rather can be
+bypassed by the --no-post-hooks. It is meant primarily for notification and its
+exit status does not have any effect.
 
 # PASSWORDS
 


### PR DESCRIPTION
Add option to bypass post hooks just like the --no-verify option allows to bypass pre hooks which I needed for a specific use case. EXECUTE_HOOKS could be renamed to EXECUTE_PRE_HOOKS for specificity, but I didn't want to break any code that could use it unbeknownst to me.