### PR TITLE
Clarifying setup of custom curl for Apple Silicon

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -115,8 +115,10 @@ cd /your/unpacked/archive
 
 brew install openssl
 brew install libssh2
+brew install libpsl
 
-./configure -q --with-libssh2 --with-ssl=/usr/local/opt/openssl
+
+./configure --with-libssh2 --with-openssl=$(brew --prefix openssl) --with-libpsl=$(brew --prefix libpsl)
 make
 make install
 ```


### PR DESCRIPTION
Hi! Newer versions of macs with Apple Silicon don't seem to come built in with libpsl, so I've added this line to make sure people know to install it up-front when going through these instructions. 

Also, Apple Silicon has a different folder prefix for HomeBrew, so using the brew --prefix command to build the command fixes the issue for those that are migrating from an Intel mac to an Apple Silicon one.