### PR TITLE
Add possibility to use different password managers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# https://editorconfig.org
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+indent_size = 8

--- a/git-ftp
+++ b/git-ftp
@@ -176,6 +176,7 @@ OPTIONS
 	-u, --user		FTP login name.
 	-p, --passwd		FTP password.
 	-P, --ask-passwd	Ask for FTP password interactively.
+	--password-command	FTP password from arbitrary bash command.
 	-k, --keychain		FTP password from KeyChain (Mac OS X only).
 	-b, --branch		Git branch to push
 	-s, --scope		Using a scope (e.g. dev, production, testing).
@@ -1041,9 +1042,13 @@ set_remote_cacert() {
 }
 
 set_remote_password() {
+	[ -z "$PASSWORD_COMMAND" ] && PASSWORD_COMMAND="$(get_config password-command)"
+	[ -z "$REMOTE_PASSWD" ] && [ -n "$PASSWORD_COMMAND" ] && REMOTE_PASSWD=$(bash -c "$PASSWORD_COMMAND")
+
 	KEYCHAIN_USER="$(get_config keychain)"
 	[ -z "$KEYCHAIN_USER" ] || USE_KEYCHAIN=1
 	[ -z "$REMOTE_PASSWD" ] && [ $USE_KEYCHAIN -eq 1 ] && get_keychain_password "$KEYCHAIN_USER"
+
 	[ -z "$REMOTE_PASSWD" ] && REMOTE_PASSWD="$(get_config password)"
 }
 
@@ -1661,6 +1666,24 @@ do
 			;;
 		-P|--ask-passwd)
 			ask_for_passwd
+			;;
+		--password-command*)
+			case "$#,$1" in
+				*,*=*)
+					PASSWORD_COMMAND=$(expr "z$1" : 'z-[^=]*=\(.*\)')
+					;;
+				1,*)
+					print_error_and_die "Too few arguments for option --password-command." "$ERROR_MISSING_ARGUMENTS"
+					;;
+				*)
+					if ! echo "$2" | egrep -q '^-'; then
+						PASSWORD_COMMAND="$2"
+						shift
+					else
+						print_error_and_die "Too few arguments for option --password-command." "$ERROR_MISSING_ARGUMENTS"
+					fi
+					;;
+			esac
 			;;
 		-k|--keychain*)
 			USE_KEYCHAIN=1

--- a/man/git-ftp.1.md
+++ b/man/git-ftp.1.md
@@ -93,6 +93,9 @@ different and handles only those files. That saves time and bandwidth.
 `-P`, `--ask-passwd`
 :	Ask for FTP password interactively.
 
+`--password-command [command]`
+:	FTP password from arbitrary bash command.
+
 `-k [[account]@[host]]`, `--keychain [[account]@[host]]`
 :	FTP password from KeyChain (macOS only).
 
@@ -602,6 +605,25 @@ For example, if you set up your .netrc file like this you can just call
 	git ftp init ftp.example.com
 
 Of course this can be combined with the [defaults feature](#defaults) to set config defaults for other options as well.
+
+## Password managers
+
+You can use an arbitrary `bash` command to retrieve the password.
+In the following examples, we'll use the password manager [pass](https://www.passwordstore.org/).
+
+You can specify the command with the option `--password-command`:
+
+	$ git ftp init --password-command "pass show host"
+
+Or you can set a config for this, so you don’t need to repeat yourself:
+
+	$ git config git-ftp.password-command "pass show host"
+
+Since it is an arbitrary `bash` command, you can for example use pipes:
+
+	$ git ftp push --password-command "pass show host |head -1"
+
+The command-line option takes precedence over the configured value.
 
 ## Keychain on macOS
 

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -167,6 +167,59 @@ test_init_invalid_user() {
 	assertEquals $ERROR_UPLOAD $rtrn
 }
 
+test_init_password_command_cli() {
+	git config git-ftp.url "$GIT_FTP_URL"
+	git config git-ftp.user "$GIT_FTP_USER"
+	init="$($GIT_FTP_CMD init --password-command "echo '$GIT_FTP_PASSWD'")"
+	rtrn=$?
+	assertEquals 0 $rtrn
+	assertTrue 'file does not exist' "remote_file_exists 'test 1.txt'"
+	assertTrue 'file differs' "remote_file_equals 'test 1.txt'"
+}
+
+test_init_invalid_password_command_cli() {
+	REMOTE_BASE_URL_DISPLAY="ftp://$GIT_FTP_USER:***@$GIT_FTP_HOST$GIT_FTP_PORT"
+	git config git-ftp.url "$GIT_FTP_URL"
+	git config git-ftp.user "$GIT_FTP_USER"
+	init="$($GIT_FTP_CMD init --password-command "echo 'wrong-$GIT_FTP_PASSWD'" 2>&1)"
+	rtrn=$?
+	assertEquals "fatal:  Can't access remote '$REMOTE_BASE_URL_DISPLAY'. Failed to log in. Correct user and password? exiting..." "$init"
+	assertEquals $ERROR_UPLOAD $rtrn
+}
+
+test_init_password_command_config() {
+	git config git-ftp.url "$GIT_FTP_URL"
+	git config git-ftp.user "$GIT_FTP_USER"
+	git config git-ftp.password-command "echo '$GIT_FTP_PASSWD'"
+	init="$($GIT_FTP_CMD init)"
+	rtrn=$?
+	assertEquals 0 $rtrn
+	assertTrue 'file does not exist' "remote_file_exists 'test 1.txt'"
+	assertTrue 'file differs' "remote_file_equals 'test 1.txt'"
+}
+
+test_init_invalid_password_command_config() {
+	REMOTE_BASE_URL_DISPLAY="ftp://$GIT_FTP_USER:***@$GIT_FTP_HOST$GIT_FTP_PORT"
+	git config git-ftp.url "$GIT_FTP_URL"
+	git config git-ftp.user "$GIT_FTP_USER"
+	git config git-ftp.password-command "echo 'wrong-$GIT_FTP_PASSWD'"
+	init="$($GIT_FTP_CMD init 2>&1)"
+	rtrn=$?
+	assertEquals "fatal:  Can't access remote '$REMOTE_BASE_URL_DISPLAY'. Failed to log in. Correct user and password? exiting..." "$init"
+	assertEquals $ERROR_UPLOAD $rtrn
+}
+
+test_init_password_command_cli_takes_precedence() {
+	git config git-ftp.url "$GIT_FTP_URL"
+	git config git-ftp.user "$GIT_FTP_USER"
+	git config git-ftp.password-command "echo 'wrong-$GIT_FTP_PASSWD'"
+	init="$($GIT_FTP_CMD init --password-command "echo '$GIT_FTP_PASSWD'")"
+	rtrn=$?
+	assertEquals 0 $rtrn
+	assertTrue 'file does not exist' "remote_file_exists 'test 1.txt'"
+	assertTrue 'file differs' "remote_file_equals 'test 1.txt'"
+}
+
 test_inits_and_pushes() {
 
 	# this should pass

--- a/tests/git-ftp-test.sh
+++ b/tests/git-ftp-test.sh
@@ -1428,14 +1428,15 @@ disabled_test_file_named_dash() {
 }
 
 remote_file_exists() {
-	$CURL "$CURL_URL/$1" --head > /dev/null
+	local file="$1"
+	$CURL "$CURL_URL/${file// /%20}" --head > /dev/null
 }
 
 remote_file_equals() {
 	local file="$1"
 	local remote="$2"
 	[ -z "$remote" ] && remote="$file"
-	$CURL -s "$CURL_URL/$remote" | diff - -- "$file" > /dev/null
+	$CURL -s "$CURL_URL/${remote// /%20}" | diff - -- "$file" > /dev/null
 }
 
 assertRemoteFileExists() {


### PR DESCRIPTION
The option `password-command` and the corresponding command-line argument `--password-command` were added in order to allow plugging in any password manager that allows printing a password to `stdout`, not just OSX KeyChain. Other examples include [pass](https://www.passwordstore.org) and [KeyPassXC](https://github.com/keepassxreboot/keepassxc/blob/latest/docs/man/keepassxc-cli.1.adoc).

Some test helpers had to be fixed because `curl` stopped accepting spaces in URLs. Cf. curl/curl#8654

An [.editorconfig](https://editorconfig.org) was added to make contribution easier. Should I remove this or make a separate PR?