### PR TITLE
Use grep -E instead of egrep

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -641,7 +641,7 @@ set_remote_protocol() {
 		write_log "Protocol not set, using default protocol $DEFAULT_PROTOCOL://."
 		REMOTE_PROTOCOL="$DEFAULT_PROTOCOL"
 		CURL_PROTOCOL="$REMOTE_PROTOCOL"
-		echo "$URL" | egrep -q "/" && REMOTE_PATH=$(echo "$URL" | cut -d '/' -f 2-)
+		echo "$URL" | grep -E -q "/" && REMOTE_PATH=$(echo "$URL" | cut -d '/' -f 2-)
 		handle_remote_protocol_options
 		return
 	fi
@@ -652,12 +652,12 @@ set_remote_path() {
 	# Check remote root directory
 	[ -z "$REMOTE_ROOT" ] && REMOTE_ROOT="$(get_config remote-root)"
 	if [ ! -z "$REMOTE_ROOT" ]; then
-		! echo "$REMOTE_ROOT" | egrep -q "/$" && REMOTE_ROOT="$REMOTE_ROOT/"
+		! echo "$REMOTE_ROOT" | grep -E -q "/$" && REMOTE_ROOT="$REMOTE_ROOT/"
 		REMOTE_PATH="$REMOTE_ROOT$REMOTE_PATH"
 	fi
 
 	# Add trailing slash if missing
-	if [ ! -z "$REMOTE_PATH" ] && ! echo "$REMOTE_PATH" | egrep -q "/$"; then
+	if [ ! -z "$REMOTE_PATH" ] && ! echo "$REMOTE_PATH" | grep -E -q "/$"; then
 		write_log "Added missing trailing / in path."
 		REMOTE_PATH="$REMOTE_PATH/"
 	fi
@@ -1186,7 +1186,7 @@ set_merge_args() {
 }
 
 get_protocol_of_url() {
-	echo "$1" | tr '[:upper:]' '[:lower:]' | egrep '^(ftp|sftp|ftps|ftpes)://' | cut -d ':' -f 1
+	echo "$1" | tr '[:upper:]' '[:lower:]' | grep -E '^(ftp|sftp|ftps|ftpes)://' | cut -d ':' -f 1
 }
 
 download_remote_updates () {
@@ -1559,7 +1559,7 @@ do
 					REMOTE_USER="$USER"
 					;;
 				*)
-					if ! echo "$2" | egrep -q '^-'; then
+					if ! echo "$2" | grep -E -q '^-'; then
 						REMOTE_USER="$2"
 						shift
 					else
@@ -1577,7 +1577,7 @@ do
 					check_is_git_project && SCOPE="$(git rev-parse --abbrev-ref HEAD)"
 					;;
 				*)
-					if ! echo "$2" | egrep -q '^-'; then
+					if ! echo "$2" | grep -E -q '^-'; then
 						SCOPE="$2"
 						shift
 					else
@@ -1599,7 +1599,7 @@ do
 					print_error_and_die "Too few arguments for option --branch." "$ERROR_MISSING_ARGUMENTS"
 					;;
 				*)
-					if ! echo "$2" | egrep -q '^-'; then
+					if ! echo "$2" | grep -E -q '^-'; then
 						BRANCH="$2"
 						shift
 					else
@@ -1617,7 +1617,7 @@ do
 					print_error_and_die "Too few arguments for option --syncroot." "$ERROR_MISSING_ARGUMENTS"
 					;;
 				*)
-					if ! echo "$2" | egrep -q '^-'; then
+					if ! echo "$2" | grep -E -q '^-'; then
 						SYNCROOT="$2"
 						shift
 					else
@@ -1636,7 +1636,7 @@ do
 					print_error_and_die "Too few arguments for option -c." "$ERROR_MISSING_ARGUMENTS"
 					;;
 				*)
-					if ! echo "$2" | egrep -q '^-'; then
+					if ! echo "$2" | grep -E -q '^-'; then
 						DEPLOYED_SHA1="$2"
 						shift
 					else
@@ -1655,7 +1655,7 @@ do
 					print_error_and_die "Too few arguments for option -p." "$ERROR_MISSING_ARGUMENTS"
 					;;
 				*)
-					if ! echo "$2" | egrep -q '^-'; then
+					if ! echo "$2" | grep -E -q '^-'; then
 						REMOTE_PASSWD="$2"
 						shift
 					else
@@ -1676,7 +1676,7 @@ do
 					print_error_and_die "Too few arguments for option --password-command." "$ERROR_MISSING_ARGUMENTS"
 					;;
 				*)
-					if ! echo "$2" | egrep -q '^-'; then
+					if ! echo "$2" | grep -E -q '^-'; then
 						PASSWORD_COMMAND="$2"
 						shift
 					else
@@ -1696,7 +1696,7 @@ do
 					# Nothing is handed over, this is okay
 					;;
 				*)
-					if ! echo "$2" | egrep -q '^-'; then
+					if ! echo "$2" | grep -E -q '^-'; then
 						KEYCHAIN_USER="$2"
 						shift
 					fi
@@ -1755,7 +1755,7 @@ do
 					print_error_and_die "Too few arguments for option --cacert" "$ERROR_MISSING_ARGUMENTS"
 					;;
 				*)
-					if ! echo "$2" | egrep -q '^-'; then
+					if ! echo "$2" | grep -E -q '^-'; then
 						REMOTE_CACERT="$2"
 						shift
 					else
@@ -1773,7 +1773,7 @@ do
 					print_error_and_die "Too few arguments for option --key." "$ERROR_MISSING_ARGUMENTS"
 					;;
 				*)
-					if ! echo "$2" | egrep -q '^-'; then
+					if ! echo "$2" | grep -E -q '^-'; then
 						CURL_PRIVATE_KEY="$2"
 						shift
 					else
@@ -1791,7 +1791,7 @@ do
 					print_error_and_die "Too few arguments for option --pubkey." "$ERROR_MISSING_ARGUMENTS"
 					;;
 				*)
-					if ! echo "$2" | egrep -q '^-'; then
+					if ! echo "$2" | grep -E -q '^-'; then
 						CURL_PUBLIC_KEY="$2"
 						shift
 					else
@@ -1849,7 +1849,7 @@ do
 					print_error_and_die "Too few arguments for option --proxy." "$ERROR_MISSING_ARGUMENTS"
 					;;
 				*)
-					if ! echo "$2" | egrep -q '^-'; then
+					if ! echo "$2" | grep -E -q '^-'; then
 						CURL_PROXY="$2"
 						shift
 					else

--- a/tests/shunit2-2.1.6/src/shunit2
+++ b/tests/shunit2-2.1.6/src/shunit2
@@ -968,7 +968,7 @@ _shunit_extractTestFunctions()
   # extract the lines with test function names, strip of anything besides the
   # function name, and output everything on a single line.
   _shunit_regex_='^[ 	]*(function )*test[A-Za-z0-9_]* *\(\)'
-  egrep "${_shunit_regex_}" "${_shunit_script_}" \
+   grep -E "${_shunit_regex_}" "${_shunit_script_}" \
   |sed 's/^[^A-Za-z0-9_]*//;s/^function //;s/\([A-Za-z0-9_]*\).*/\1/g' \
   |xargs
 


### PR DESCRIPTION
While using this project I found the following warning :

> warning: egrep is obsolescent; using grep -E

And after looking a bit into the issues I found that  #641 referenced this issue so I decided to update the bash scripts to call `grep -E` instead of `egrep`.